### PR TITLE
feat(rag): 实现精确Token 计数与熔断截断机制 closes #6

### DIFF
--- a/upstream_service/app/agent/graph.py
+++ b/upstream_service/app/agent/graph.py
@@ -1,16 +1,18 @@
 from langgraph.graph import END, START, StateGraph
 
-from app.agent.nodes import input_node, llm_node, output_node
+from app.agent.nodes import context_node, input_node, llm_node, output_node
 from app.agent.state import AgentState
 
 
 graph_builder = StateGraph(AgentState)
 graph_builder.add_node("input_node", input_node)
+graph_builder.add_node("context_node", context_node)
 graph_builder.add_node("llm_node", llm_node)
 graph_builder.add_node("output_node", output_node)
 
 graph_builder.add_edge(START, "input_node")
-graph_builder.add_edge("input_node", "llm_node")
+graph_builder.add_edge("input_node", "context_node")
+graph_builder.add_edge("context_node", "llm_node")
 graph_builder.add_edge("llm_node", "output_node")
 graph_builder.add_edge("output_node", END)
 

--- a/upstream_service/app/agent/nodes.py
+++ b/upstream_service/app/agent/nodes.py
@@ -1,9 +1,18 @@
+import traceback
+
 from app.agent.state import AgentState
 from app.core.config import settings
 from app.services.llm_service import llm_service
+from app.services.rag_service import (
+    RAG_TOKEN_LIMIT,
+    build_context_text as build_context_text_from_rag_service,
+    count_tokens,
+    get_token_encoding as get_rag_token_encoding,
+)
 
 
 CYBER_HACK_PREFIX = "[Cyber Hack]"
+RAG_INSTRUCTION = "请仅根据提供的背景上下文回答问题。如果上下文不足以回答，请直说不知道。"
 
 
 def ensure_cyber_hack_style(text: str) -> str:
@@ -15,27 +24,76 @@ def ensure_cyber_hack_style(text: str) -> str:
     return f"{CYBER_HACK_PREFIX} {cleaned}"
 
 
+def get_token_encoding():
+    return get_rag_token_encoding()
+
+
+def build_context_text(documents: list[str], token_limit: int = RAG_TOKEN_LIMIT) -> str:
+    base_context_text = build_context_text_from_rag_service(documents, token_limit=token_limit)
+    if not base_context_text:
+        return ""
+
+    context_body = base_context_text
+    current_tokens = count_tokens(context_body)
+    context_text = f"# Context Tokens: {current_tokens}\n{context_body}"
+
+    while count_tokens(context_text) > token_limit and context_body:
+        print("[RAG] 警告：上下文最终检查仍超限，开始执行暴力字符截断")
+        context_body = context_body[:-64].rstrip()
+        current_tokens = count_tokens(context_body)
+        context_text = f"# Context Tokens: {current_tokens}\n{context_body}"
+
+    final_tokens = count_tokens(context_text)
+    if final_tokens > token_limit:
+        print(f"[RAG] 严重警告：上下文仍超过 {token_limit} Tokens，请检查模板开销估算")
+
+    return context_text
+
+
 def input_node(state: AgentState) -> AgentState:
     print("收到用户输入")
     return {
         "messages": state.get("messages", []),
+        "documents": state.get("documents", []),
+        "context_text": state.get("context_text", ""),
+        "next_step": "context_node",
+        "model": state.get("model"),
+        "temperature": state.get("temperature"),
+        "final_response": state.get("final_response"),
+    }
+
+
+def context_node(state: AgentState) -> AgentState:
+    context_text = build_context_text(state.get("documents", []))
+    return {
+        "messages": state.get("messages", []),
+        "documents": state.get("documents", []),
+        "context_text": context_text,
         "next_step": "llm_node",
+        "model": state.get("model"),
+        "temperature": state.get("temperature"),
         "final_response": state.get("final_response"),
     }
 
 
 async def llm_node(state: AgentState) -> AgentState:
-    messages = [
-        {
-            "role": "system",
-            "content": settings.default_system_prompt,
-        }
-    ]
-    messages.extend(state.get("messages", []))
+    system_prompt = settings.default_system_prompt
+    context_text = state.get("context_text", "").strip()
+    if context_text:
+        system_prompt = f"{system_prompt}\n\n{RAG_INSTRUCTION}\n\n{context_text}"
+
+    messages = [{"role": "system", "content": system_prompt}, *state.get("messages", [])]
 
     try:
-        reply = await llm_service.generate_reply(messages=messages)
+        reply = await llm_service.generate_reply(
+            messages=messages,
+            model=state.get("model"),
+            temperature=state.get("temperature", 0.7),
+        )
         reply = ensure_cyber_hack_style(reply)
+    except AssertionError:
+        traceback.print_exc()
+        raise
     except Exception:
         reply = f"{CYBER_HACK_PREFIX} 核心链路断开，该死的服务器又在装死。"
 
@@ -46,7 +104,11 @@ async def llm_node(state: AgentState) -> AgentState:
 
     return {
         "messages": updated_messages,
+        "documents": state.get("documents", []),
+        "context_text": state.get("context_text", ""),
         "next_step": "output_node",
+        "model": state.get("model"),
+        "temperature": state.get("temperature"),
         "final_response": state.get("final_response"),
     }
 
@@ -62,6 +124,10 @@ def output_node(state: AgentState) -> AgentState:
 
     return {
         "messages": state.get("messages", []),
+        "documents": state.get("documents", []),
+        "context_text": state.get("context_text", ""),
         "next_step": "end",
+        "model": state.get("model"),
+        "temperature": state.get("temperature"),
         "final_response": final_response,
     }

--- a/upstream_service/app/agent/state.py
+++ b/upstream_service/app/agent/state.py
@@ -3,5 +3,9 @@ from typing import NotRequired, TypedDict
 
 class AgentState(TypedDict):
     messages: list[dict[str, str]]
+    documents: list[str]
+    context_text: str
     next_step: str
+    model: NotRequired[str | None]
+    temperature: NotRequired[float | None]
     final_response: NotRequired[str | None]

--- a/upstream_service/app/api/routes.py
+++ b/upstream_service/app/api/routes.py
@@ -3,6 +3,7 @@ import uuid
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse, StreamingResponse
+from app.agent.graph import graph_app
 from app.api.schemas import ChatCompletionRequest
 from app.services.llm_service import llm_service
 
@@ -21,13 +22,19 @@ async def chat_completions(request: ChatCompletionRequest):
             },
         )
 
-    model_name = llm_service.resolve_model(request.model)
-    messages = llm_service.build_messages(request)
-    content = await llm_service.generate_reply(
-        messages=messages,
-        model=request.model,
-        temperature=request.temperature,
+    result = await graph_app.ainvoke(
+        {
+            "messages": [message.model_dump() for message in request.messages],
+            "documents": request.documents or [],
+            "context_text": "",
+            "next_step": "input_node",
+            "model": request.model,
+            "temperature": request.temperature,
+            "final_response": None,
+        }
     )
+    model_name = llm_service.resolve_model(request.model)
+    content = result.get("final_response") or ""
 
     payload = {
         "id": f"chatcmpl-{uuid.uuid4().hex}",

--- a/upstream_service/app/api/schemas.py
+++ b/upstream_service/app/api/schemas.py
@@ -17,6 +17,7 @@ class ChatCompletionRequest(BaseModel):
         description="请求调用的模型名称；传 agent-core-v1 时会回退到服务端默认模型",
     )
     messages: List[ChatMessage] = Field(..., description="历史对话列表，最后一项为当前问题")
+    documents: Optional[List[str]] = Field(default=None, description="可选 RAG 文档列表")
     stream: Optional[bool] = Field(default=False, description="是否使用 SSE 流式输出")
     temperature: Optional[float] = Field(default=0.7, ge=0.0, le=2.0, description="大模型的发散度")
 

--- a/upstream_service/app/services/rag_service.py
+++ b/upstream_service/app/services/rag_service.py
@@ -1,0 +1,72 @@
+import tiktoken
+
+
+RAG_TOKEN_LIMIT = 2000
+RAG_TEMPLATE_TOKEN_OVERHEAD = 50
+RAG_ENCODING_MODEL = "gpt-3.5-turbo"
+
+
+def get_token_encoding():
+    try:
+        return tiktoken.encoding_for_model(RAG_ENCODING_MODEL)
+    except KeyError:
+        return tiktoken.get_encoding("cl100k_base")
+
+
+def count_tokens(text: str) -> int:
+    return len(get_token_encoding().encode(text))
+
+
+def truncate_to_token_limit(text: str, token_limit: int) -> str:
+    encoding = get_token_encoding()
+    token_ids = encoding.encode(text)
+    if len(token_ids) <= token_limit:
+        return text
+    return encoding.decode(token_ids[:token_limit])
+
+
+def build_context_text(documents: list[str], token_limit: int = RAG_TOKEN_LIMIT) -> str:
+    if not documents:
+        return ""
+
+    header = "Background Context:\n---\n"
+    footer = "\n---"
+    final_limit = max(1, token_limit - RAG_TEMPLATE_TOKEN_OVERHEAD)
+
+    parts = [header]
+    truncated = False
+
+    for index, document in enumerate(documents, start=1):
+        cleaned_document = document.strip()
+        if not cleaned_document:
+            continue
+
+        document_prefix = f"[Document {index}]: "
+        document_suffix = "\n"
+        full_block = f"{document_prefix}{cleaned_document}{document_suffix}"
+        candidate_text = "".join(parts) + full_block + footer
+
+        if count_tokens(candidate_text) <= final_limit:
+            parts.append(full_block)
+            continue
+
+        prefix_text = "".join(parts) + document_prefix
+        remaining_budget = final_limit - count_tokens(prefix_text + footer + document_suffix)
+        if remaining_budget > 0:
+            truncated_document = truncate_to_token_limit(cleaned_document, remaining_budget)
+            truncated_block = f"{document_prefix}{truncated_document}{document_suffix}"
+            candidate_text = "".join(parts) + truncated_block + footer
+            if count_tokens(candidate_text) <= final_limit and truncated_document:
+                parts.append(truncated_block)
+
+        truncated = True
+        break
+
+    final_text = "".join(parts) + footer
+    if count_tokens(final_text) > final_limit:
+        final_text = truncate_to_token_limit(final_text, final_limit)
+
+    if truncated:
+        print(f"[RAG] 文档过长，已截断至 {token_limit} Tokens")
+
+    return final_text

--- a/upstream_service/tests/test_rag.py
+++ b/upstream_service/tests/test_rag.py
@@ -1,0 +1,102 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.agent.graph import graph_app
+from app.agent.nodes import RAG_TOKEN_LIMIT, get_token_encoding
+from app.services.llm_service import llm_service
+
+
+def build_long_documents() -> list[str]:
+    base_line = (
+        "RAG 边界测试文档。关键事实：天穹数据库的主键是 SKY-42，"
+        "回滚口令是 ALPHA-OMEGA，维护窗口在周三 03:00。"
+    )
+    long_document = base_line * 80
+    return [long_document for _ in range(10)]
+
+
+def extract_context_from_messages(messages: list[dict]) -> str:
+    if not messages:
+        return ""
+    system_prompt = messages[0].get("content", "")
+    marker = "Background Context:"
+    start_index = system_prompt.find(marker)
+    if start_index == -1:
+        return ""
+    return system_prompt[start_index:].strip()
+
+
+async def run_test() -> None:
+    documents = build_long_documents()
+    original_total_length = sum(len(document) for document in documents)
+    encoding = get_token_encoding()
+
+    initial_state = {
+        "messages": [
+            {"role": "user", "content": "请告诉我天穹数据库的主键和回滚口令。"}
+        ],
+        "documents": documents,
+        "context_text": "",
+        "next_step": "input_node",
+        "model": "agent-core-v1",
+        "temperature": 0.2,
+        "final_response": None,
+    }
+
+    async def fake_generate_reply(*, messages, model=None, temperature=0.7):
+        context_text = extract_context_from_messages(messages)
+        assert context_text, "context_text 没有注入到 system prompt 中"
+
+        context_tokens = len(encoding.encode(context_text))
+        assert context_tokens <= RAG_TOKEN_LIMIT, "context_text 超过了 Token 截断阈值"
+
+        has_key_fact = "SKY-42" in context_text
+        has_password_fact = "ALPHA-OMEGA" in context_text
+        return (
+            "[Cyber Hack] 已锁定背景文档。"
+            f" 主键=SKY-42({has_key_fact})，回滚口令=ALPHA-OMEGA({has_password_fact})，"
+            f" 上下文Token={context_tokens}"
+        )
+
+    original_generate_reply = llm_service.generate_reply
+    llm_service.generate_reply = fake_generate_reply
+
+    try:
+        print("[RAG Test] 开始执行长文档边界测试")
+        print(f"[RAG Test] 原本文档总长度: {original_total_length}")
+        print(f"[RAG Test] 文档数量: {len(documents)}")
+
+        result = await graph_app.ainvoke(initial_state)
+    finally:
+        llm_service.generate_reply = original_generate_reply
+
+    context_text = result.get("context_text", "")
+    truncated_length = len(context_text)
+    truncated_tokens = len(encoding.encode(context_text))
+    final_response = result.get("final_response", "")
+
+    print(f"[RAG Test] 截断后的上下文长度: {truncated_length}")
+    print(f"[RAG Test] 截断后的上下文Token数: {truncated_tokens}")
+    print("[RAG Test] 最终状态:")
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    print("[RAG Test] 大模型最终回答:")
+    print(final_response)
+
+    assert truncated_tokens <= RAG_TOKEN_LIMIT, "截断后的上下文仍然超过 Token 上限"
+    assert "SKY-42" in final_response, "最终回复没有引用文档中的主键"
+    assert "ALPHA-OMEGA" in final_response, "最终回复没有引用文档中的回滚口令"
+
+
+if __name__ == "__main__":
+    asyncio.run(run_test())


### PR DESCRIPTION
## 📝 变更背景
在 RAG 集成测试中发现，传统的字符串长度截断无法准确控制 Token 消耗，导致在长文档输入时频繁触发上游 API 的 ContextWindowExceeded 错误。

## 🔗 关联 Issue
Closes #6

## 🛠️ 技术实现
1. **精确计数**：集成 `tiktoken` 库，替代了模糊的字符长度计算。
2. **熔断逻辑**：在 `rag_service.py` 中引入了 `RAG_TOKEN_LIMIT` 硬限制，并在拼接前预留了 50 Tokens 的安全余量。
3. **调试优化**：修改了状态机节点的异常拦截逻辑，确保 `AssertionError` 能在终端直接打印 Traceback，提升了测试效率。

