### PR TITLE
feat: 实现动态工具调用节点与 ReAct 逻辑循环 closes #7

### DIFF
--- a/upstream_service/app/agent/graph.py
+++ b/upstream_service/app/agent/graph.py
@@ -1,19 +1,32 @@
 from langgraph.graph import END, START, StateGraph
 
-from app.agent.nodes import context_node, input_node, llm_node, output_node
+from app.agent.nodes import action_node, context_node, input_node, llm_node, output_node
 from app.agent.state import AgentState
+
+
+def route_after_llm(state: AgentState) -> str:
+    return state.get("next_step", "output_node")
 
 
 graph_builder = StateGraph(AgentState)
 graph_builder.add_node("input_node", input_node)
 graph_builder.add_node("context_node", context_node)
 graph_builder.add_node("llm_node", llm_node)
+graph_builder.add_node("action_node", action_node)
 graph_builder.add_node("output_node", output_node)
 
 graph_builder.add_edge(START, "input_node")
 graph_builder.add_edge("input_node", "context_node")
 graph_builder.add_edge("context_node", "llm_node")
-graph_builder.add_edge("llm_node", "output_node")
+graph_builder.add_conditional_edges(
+    "llm_node",
+    route_after_llm,
+    {
+        "action_node": "action_node",
+        "output_node": "output_node",
+    },
+)
+graph_builder.add_edge("action_node", "llm_node")
 graph_builder.add_edge("output_node", END)
 
 graph_app = graph_builder.compile()

--- a/upstream_service/app/agent/nodes.py
+++ b/upstream_service/app/agent/nodes.py
@@ -1,6 +1,7 @@
 import traceback
 
 from app.agent.state import AgentState
+from app.agent.tools import AVAILABLE_TOOLS, execute_tool, parse_tool_arguments
 from app.core.config import settings
 from app.services.llm_service import llm_service
 from app.services.rag_service import (
@@ -59,6 +60,7 @@ def input_node(state: AgentState) -> AgentState:
         "next_step": "context_node",
         "model": state.get("model"),
         "temperature": state.get("temperature"),
+        "tool_rounds": state.get("tool_rounds", 0),
         "final_response": state.get("final_response"),
     }
 
@@ -72,6 +74,7 @@ def context_node(state: AgentState) -> AgentState:
         "next_step": "llm_node",
         "model": state.get("model"),
         "temperature": state.get("temperature"),
+        "tool_rounds": state.get("tool_rounds", 0),
         "final_response": state.get("final_response"),
     }
 
@@ -85,30 +88,72 @@ async def llm_node(state: AgentState) -> AgentState:
     messages = [{"role": "system", "content": system_prompt}, *state.get("messages", [])]
 
     try:
-        reply = await llm_service.generate_reply(
+        assistant_message = await llm_service.generate_message(
             messages=messages,
             model=state.get("model"),
             temperature=state.get("temperature", 0.7),
+            tools=AVAILABLE_TOOLS,
         )
-        reply = ensure_cyber_hack_style(reply)
+        if not assistant_message.get("tool_calls"):
+            assistant_message["content"] = ensure_cyber_hack_style(
+                str(assistant_message.get("content") or "")
+            )
+        can_call_tool = state.get("tool_rounds", 0) < 1
+        next_step = "action_node" if assistant_message.get("tool_calls") and can_call_tool else "output_node"
     except AssertionError:
         traceback.print_exc()
         raise
     except Exception:
-        reply = f"{CYBER_HACK_PREFIX} 核心链路断开，该死的服务器又在装死。"
+        assistant_message = {
+            "role": "assistant",
+            "content": f"{CYBER_HACK_PREFIX} 核心链路断开，该死的服务器又在装死。",
+        }
+        next_step = "output_node"
 
     updated_messages = [
         *state.get("messages", []),
-        {"role": "assistant", "content": reply},
+        assistant_message,
     ]
 
     return {
         "messages": updated_messages,
         "documents": state.get("documents", []),
         "context_text": state.get("context_text", ""),
-        "next_step": "output_node",
+        "next_step": next_step,
         "model": state.get("model"),
         "temperature": state.get("temperature"),
+        "tool_rounds": state.get("tool_rounds", 0),
+        "final_response": state.get("final_response"),
+    }
+
+
+def action_node(state: AgentState) -> AgentState:
+    messages = state.get("messages", [])
+    last_message = messages[-1] if messages else {}
+    tool_messages = []
+
+    for tool_call in last_message.get("tool_calls", []) or []:
+        function_info = tool_call.get("function", {})
+        tool_name = function_info.get("name", "")
+        arguments = parse_tool_arguments(function_info.get("arguments"))
+        result = execute_tool(tool_name, arguments)
+        tool_messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": tool_call.get("id"),
+                "name": tool_name,
+                "content": result,
+            }
+        )
+
+    return {
+        "messages": [*messages, *tool_messages],
+        "documents": state.get("documents", []),
+        "context_text": state.get("context_text", ""),
+        "next_step": "llm_node",
+        "model": state.get("model"),
+        "temperature": state.get("temperature"),
+        "tool_rounds": state.get("tool_rounds", 0) + 1,
         "final_response": state.get("final_response"),
     }
 
@@ -129,5 +174,6 @@ def output_node(state: AgentState) -> AgentState:
         "next_step": "end",
         "model": state.get("model"),
         "temperature": state.get("temperature"),
+        "tool_rounds": state.get("tool_rounds", 0),
         "final_response": final_response,
     }

--- a/upstream_service/app/agent/state.py
+++ b/upstream_service/app/agent/state.py
@@ -1,11 +1,12 @@
-from typing import NotRequired, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 
 class AgentState(TypedDict):
-    messages: list[dict[str, str]]
+    messages: list[dict[str, Any]]
     documents: list[str]
     context_text: str
     next_step: str
     model: NotRequired[str | None]
     temperature: NotRequired[float | None]
+    tool_rounds: NotRequired[int]
     final_response: NotRequired[str | None]

--- a/upstream_service/app/agent/tools.py
+++ b/upstream_service/app/agent/tools.py
@@ -1,0 +1,60 @@
+import json
+from collections.abc import Callable
+from typing import Any
+
+
+WEATHER_TOOL_NAME = "mock_weather_tool"
+
+
+def mock_weather_tool(city: str) -> str:
+    weather_map = {
+        "北京": "北京今天天气晴，气温 22C，东北风 2 级。",
+        "上海": "上海今天天气多云，气温 25C，东南风 3 级。",
+        "广州": "广州今天天气小雨，气温 28C，南风 2 级。",
+    }
+    return weather_map.get(city, f"{city}今天天气未知，当前为本地工具模拟结果。")
+
+
+WEATHER_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": WEATHER_TOOL_NAME,
+        "description": "查询指定城市的模拟天气信息。",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "需要查询天气的城市名称，例如北京、上海、广州。",
+                }
+            },
+            "required": ["city"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+AVAILABLE_TOOLS = [WEATHER_TOOL_SCHEMA]
+TOOL_REGISTRY: dict[str, Callable[..., str]] = {
+    WEATHER_TOOL_NAME: mock_weather_tool,
+}
+
+
+def parse_tool_arguments(raw_arguments: str | dict[str, Any] | None) -> dict[str, Any]:
+    if raw_arguments is None:
+        return {}
+    if isinstance(raw_arguments, dict):
+        return raw_arguments
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def execute_tool(name: str, arguments: dict[str, Any]) -> str:
+    tool = TOOL_REGISTRY.get(name)
+    if tool is None:
+        return f"未知工具: {name}"
+    return tool(**arguments)

--- a/upstream_service/app/services/llm_service.py
+++ b/upstream_service/app/services/llm_service.py
@@ -1,7 +1,7 @@
 import json
 import time
 import uuid
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from openai import AsyncOpenAI
 
@@ -94,6 +94,52 @@ class LLMService:
             return "".join(parts)
 
         return ""
+
+    async def generate_message(
+        self,
+        *,
+        messages: list[dict],
+        model: str | None = None,
+        temperature: float | None = 0.7,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        model_name = self.resolve_model(model)
+        request_kwargs: dict[str, Any] = {
+            "model": model_name,
+            "messages": messages,
+            "temperature": temperature,
+            "stream": False,
+        }
+        if tools:
+            request_kwargs["tools"] = tools
+            request_kwargs["tool_choice"] = "auto"
+
+        response = await self.client.chat.completions.create(**request_kwargs)
+        choice = response.choices[0] if response.choices else None
+        if choice is None or choice.message is None:
+            return {"role": "assistant", "content": ""}
+
+        message = choice.message
+        payload: dict[str, Any] = {
+            "role": "assistant",
+            "content": message.content or "",
+        }
+
+        tool_calls = getattr(message, "tool_calls", None)
+        if tool_calls:
+            payload["tool_calls"] = [
+                {
+                    "id": tool_call.id,
+                    "type": tool_call.type,
+                    "function": {
+                        "name": tool_call.function.name,
+                        "arguments": tool_call.function.arguments,
+                    },
+                }
+                for tool_call in tool_calls
+            ]
+
+        return payload
 
     async def stream_chat(
         self, request: ChatCompletionRequest

--- a/upstream_service/tests/test_tools.py
+++ b/upstream_service/tests/test_tools.py
@@ -1,0 +1,96 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.agent.graph import graph_app
+
+
+EXPECTED_EFFECTIVE_ORDER = [
+    "input_node",
+    "llm_node",
+    "action_node",
+    "llm_node",
+    "output_node",
+]
+
+
+def summarize_node_state(node_name: str, state_update: dict[str, Any]) -> None:
+    messages = state_update.get("messages", [])
+    last_message = messages[-1] if messages else {}
+    final_response = state_update.get("final_response")
+
+    print(f"[Tool Test] 节点完成: {node_name}")
+    print(f"[Tool Test] next_step: {state_update.get('next_step')}")
+
+    if last_message:
+        print(f"[Tool Test] 最新消息 role: {last_message.get('role')}")
+        if last_message.get("tool_calls"):
+            print("[Tool Test] 检测到 tool_calls:")
+            print(json.dumps(last_message["tool_calls"], indent=2, ensure_ascii=False))
+        if last_message.get("role") == "tool":
+            print(f"[Tool Test] 工具返回: {last_message.get('content')}")
+
+    if final_response:
+        print(f"[Tool Test] final_response: {final_response}")
+
+
+async def run_test() -> None:
+    initial_state = {
+        "messages": [
+            {"role": "user", "content": "帮我查一下上海今天的天气。"}
+        ],
+        "documents": [],
+        "context_text": "",
+        "next_step": "input_node",
+        "model": "agent-core-v1",
+        "temperature": 0.2,
+        "tool_rounds": 0,
+        "final_response": None,
+    }
+
+    print("[Tool Test] 开始执行 LangGraph 工具调用实弹测试")
+    print("[Tool Test] 初始 State:")
+    print(json.dumps(initial_state, indent=2, ensure_ascii=False))
+
+    visited_nodes: list[str] = []
+    final_state: dict[str, Any] = {}
+
+    async for update in graph_app.astream(initial_state, stream_mode="updates"):
+        for node_name, state_update in update.items():
+            visited_nodes.append(node_name)
+            final_state.update(state_update)
+            summarize_node_state(node_name, state_update)
+
+    effective_order = [node for node in visited_nodes if node != "context_node"]
+    final_response = final_state.get("final_response") or ""
+
+    print("[Tool Test] 实际节点流转顺序:")
+    print(" -> ".join(visited_nodes))
+    print("[Tool Test] 去除空 RAG 上下文节点后的有效顺序:")
+    print(" -> ".join(effective_order))
+    print("[Tool Test] 最终回复:")
+    print(final_response)
+
+    assert effective_order == EXPECTED_EFFECTIVE_ORDER, (
+        "工具调用路由顺序不符合预期: "
+        f"expected={EXPECTED_EFFECTIVE_ORDER}, actual={effective_order}"
+    )
+    assert "[Cyber Hack]" in final_response, "最终回复缺少 [Cyber Hack] 人设前缀"
+    assert any(keyword in final_response for keyword in ["上海", "天气", "多云", "25C", "东南风"]), (
+        "最终回复没有结合 mock_weather_tool 的天气数据"
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(run_test())


### PR DESCRIPTION
- 增加 action_node 节点处理 tool_calls。
- 实现条件路由，支持 LLM 与 Tools 之间的多轮对话。
- 接入 mock_weather_tool 验证全链路通畅。
- 保持 [Cyber Hack] 人设在多轮工具调用中的稳定性。