### PR TITLE
feat: add Rerank RPC and implementation for document re-ranking    Re…

### DIFF
--- a/local_embedding_service/.gitignore
+++ b/local_embedding_service/.gitignore
@@ -18,7 +18,7 @@ generated/
 
 # Executables
 embedding_server
-local_embedding_service
+
 
 # CMake generated files
 CMakeCache.txt

--- a/local_embedding_service/CHANGELOG.md
+++ b/local_embedding_service/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Local Embedding Service project will be documented in this file.
 
+## [v4.10.0] - 2026-04-25
+
+### Added - Issue #17 Rerank 接口与批量排序
+- ✅ 新增 `Rerank(RerankRequest) -> RerankResponse` gRPC 接口
+- ✅ `RerankRequest` 支持批量 query 与 `top_k` 截断
+- ✅ 基础排序逻辑（token overlap + 稳定排序）
+- ✅ `test_all_features.sh` 增加 Rerank 端到端验证
+- ✅ 更新 README / USE_GUIDE / 使用方法文档
+
 ## [v4.5.0] - 2026-04-05
 
 ### Added - ONNX Runtime 集成与 Embedding 模型接入

--- a/local_embedding_service/README.md
+++ b/local_embedding_service/README.md
@@ -143,7 +143,24 @@ bash check_embedding_service.sh
 - ✅ 提供 fallback 方案（ONNX 初始化失败自动降级到 Mock）
 
 
+### Issue #17 验收说明(2026-04-25)
+- ✅ 新增 `Rerank(RerankRequest) -> RerankResponse` 接口
+- ✅ `RerankRequest` 支持批量 query
+- ✅ 基础排序逻辑（基于 token overlap + 稳定排序）
+
+验收标准状态：
+- ✅ 支持批量 rerank
+- ✅ 接口稳定可调用
+
+### Rerank 接口示例
+```bash
+grpcurl -plaintext -import-path proto -proto proto/embedding.proto \
+  -d '{"queries":[{"query":"hello world","documents":["hello world doc","irrelevant text","world hello again"],"top_k":2}]}' \
+  localhost:50051 embedding.EmbeddingService/Rerank
+```
+
+
 ### 文档
-- [USE_GUIDE.md](USE_GUIDE.md) - 完整使用指南（已更新 v4.5.0）
+- [USE_GUIDE.md](USE_GUIDE.md) - 完整使用指南（已更新 v4.10.0）
 - [ONNX_SETUP.md](ONNX_SETUP.md) - ONNX Runtime 安装配置
 - [CHANGELOG.md](CHANGELOG.md) - 详细变更日志

--- a/local_embedding_service/USE_GUIDE.md
+++ b/local_embedding_service/USE_GUIDE.md
@@ -1,7 +1,7 @@
 # 本模块使用方法以及启动流程
 
-> **更新日期**: 2026-04-05  
-> **版本**: v4.5.0 - 新增 ONNX Runtime 集成支持
+> **更新日期**: 2026-04-25  
+> **版本**: v4.10.0 - 新增 Rerank 接口支持
 
 ## 目录
 1. [先决条件](#0-先决条件)
@@ -260,6 +260,13 @@ grpcurl -plaintext -proto proto/embedding.proto \
 grpcurl -plaintext -proto proto/embedding.proto \
   -d '{"text":"This is a longer text to test the embedding service with more content."}' \
   localhost:50051 embedding.EmbeddingService/GetEmbedding
+```
+
+### 5.4 Rerank 排序接口
+```bash
+grpcurl -plaintext -import-path proto -proto proto/embedding.proto \
+  -d '{"queries":[{"query":"hello world","documents":["hello world doc","irrelevant text","world hello again"],"top_k":2}]}' \
+  localhost:50051 embedding.EmbeddingService/Rerank
 ```
 
 ## 6. 常见问题与排查

--- a/local_embedding_service/generated/embedding.grpc.pb.cc
+++ b/local_embedding_service/generated/embedding.grpc.pb.cc
@@ -2,15 +2,15 @@
 // If you make any local change, they will be lost.
 // source: embedding.proto
 
-#include "embedding.grpc.pb.h"
 #include "embedding.pb.h"
+#include "embedding.grpc.pb.h"
 
 #include <functional>
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
-#include <grpcpp/impl/codegen/client_callback.h>
 #include <grpcpp/impl/codegen/client_unary_call.h>
+#include <grpcpp/impl/codegen/client_callback.h>
 #include <grpcpp/impl/codegen/message_allocator.h>
 #include <grpcpp/impl/codegen/method_handler.h>
 #include <grpcpp/impl/codegen/rpc_service_method.h>
@@ -21,297 +21,212 @@
 #include <grpcpp/impl/codegen/sync_stream.h>
 namespace embedding {
 
-static const char *EmbeddingService_method_names[] = {
-    "/embedding.EmbeddingService/GetEmbedding",
-    "/embedding.EmbeddingService/GetEmbeddings",
-    "/embedding.EmbeddingService/Info",
+static const char* EmbeddingService_method_names[] = {
+  "/embedding.EmbeddingService/GetEmbedding",
+  "/embedding.EmbeddingService/GetEmbeddings",
+  "/embedding.EmbeddingService/Rerank",
+  "/embedding.EmbeddingService/Info",
 };
 
-std::unique_ptr<EmbeddingService::Stub> EmbeddingService::NewStub(
-    const std::shared_ptr<::grpc::ChannelInterface> &channel,
-    const ::grpc::StubOptions &options) {
+std::unique_ptr< EmbeddingService::Stub> EmbeddingService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
   (void)options;
-  std::unique_ptr<EmbeddingService::Stub> stub(
-      new EmbeddingService::Stub(channel));
+  std::unique_ptr< EmbeddingService::Stub> stub(new EmbeddingService::Stub(channel));
   return stub;
 }
 
-EmbeddingService::Stub::Stub(
-    const std::shared_ptr<::grpc::ChannelInterface> &channel)
-    : channel_(channel),
-      rpcmethod_GetEmbedding_(EmbeddingService_method_names[0],
-                              ::grpc::internal::RpcMethod::NORMAL_RPC, channel),
-      rpcmethod_GetEmbeddings_(EmbeddingService_method_names[1],
-                               ::grpc::internal::RpcMethod::NORMAL_RPC,
-                               channel),
-      rpcmethod_Info_(EmbeddingService_method_names[2],
-                      ::grpc::internal::RpcMethod::NORMAL_RPC, channel) {}
+EmbeddingService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
+  : channel_(channel), rpcmethod_GetEmbedding_(EmbeddingService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_GetEmbeddings_(EmbeddingService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Rerank_(EmbeddingService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Info_(EmbeddingService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  {}
 
-::grpc::Status EmbeddingService::Stub::GetEmbedding(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingRequest &request,
-    ::embedding::EmbeddingResponse *response) {
-  return ::grpc::internal::BlockingUnaryCall(
-      channel_.get(), rpcmethod_GetEmbedding_, context, request, response);
+::grpc::Status EmbeddingService::Stub::GetEmbedding(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest& request, ::embedding::EmbeddingResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetEmbedding_, context, request, response);
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbedding(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingRequest *request,
-    ::embedding::EmbeddingResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request,
-      response, std::move(f));
+void EmbeddingService::Stub::experimental_async::GetEmbedding(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest* request, ::embedding::EmbeddingResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbedding(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::EmbeddingResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request,
-      response, std::move(f));
+void EmbeddingService::Stub::experimental_async::GetEmbedding(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbedding(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingRequest *request,
-    ::embedding::EmbeddingResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request,
-      response, reactor);
+void EmbeddingService::Stub::experimental_async::GetEmbedding(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest* request, ::embedding::EmbeddingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request, response, reactor);
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbedding(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::EmbeddingResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request,
-      response, reactor);
+void EmbeddingService::Stub::experimental_async::GetEmbedding(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GetEmbedding_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::EmbeddingResponse> *
-EmbeddingService::Stub::AsyncGetEmbeddingRaw(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingRequest &request, ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::EmbeddingResponse>::Create(channel_.get(), cq,
-                                              rpcmethod_GetEmbedding_, context,
-                                              request, true);
+::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingResponse>* EmbeddingService::Stub::AsyncGetEmbeddingRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::EmbeddingResponse>::Create(channel_.get(), cq, rpcmethod_GetEmbedding_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::EmbeddingResponse> *
-EmbeddingService::Stub::PrepareAsyncGetEmbeddingRaw(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingRequest &request, ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::EmbeddingResponse>::Create(channel_.get(), cq,
-                                              rpcmethod_GetEmbedding_, context,
-                                              request, false);
+::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingResponse>* EmbeddingService::Stub::PrepareAsyncGetEmbeddingRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::EmbeddingResponse>::Create(channel_.get(), cq, rpcmethod_GetEmbedding_, context, request, false);
 }
 
-::grpc::Status EmbeddingService::Stub::GetEmbeddings(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingBatchRequest &request,
-    ::embedding::EmbeddingBatchResponse *response) {
-  return ::grpc::internal::BlockingUnaryCall(
-      channel_.get(), rpcmethod_GetEmbeddings_, context, request, response);
+::grpc::Status EmbeddingService::Stub::GetEmbeddings(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::embedding::EmbeddingBatchResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_GetEmbeddings_, context, request, response);
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbeddings(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingBatchRequest *request,
-    ::embedding::EmbeddingBatchResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request,
-      response, std::move(f));
+void EmbeddingService::Stub::experimental_async::GetEmbeddings(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest* request, ::embedding::EmbeddingBatchResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbeddings(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::EmbeddingBatchResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request,
-      response, std::move(f));
+void EmbeddingService::Stub::experimental_async::GetEmbeddings(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingBatchResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbeddings(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingBatchRequest *request,
-    ::embedding::EmbeddingBatchResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request,
-      response, reactor);
+void EmbeddingService::Stub::experimental_async::GetEmbeddings(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest* request, ::embedding::EmbeddingBatchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request, response, reactor);
 }
 
-void EmbeddingService::Stub::experimental_async::GetEmbeddings(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::EmbeddingBatchResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request,
-      response, reactor);
+void EmbeddingService::Stub::experimental_async::GetEmbeddings(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingBatchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_GetEmbeddings_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::EmbeddingBatchResponse> *
-EmbeddingService::Stub::AsyncGetEmbeddingsRaw(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingBatchRequest &request,
-    ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::EmbeddingBatchResponse>::Create(channel_.get(), cq,
-                                                   rpcmethod_GetEmbeddings_,
-                                                   context, request, true);
+::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>* EmbeddingService::Stub::AsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::EmbeddingBatchResponse>::Create(channel_.get(), cq, rpcmethod_GetEmbeddings_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::EmbeddingBatchResponse> *
-EmbeddingService::Stub::PrepareAsyncGetEmbeddingsRaw(
-    ::grpc::ClientContext *context,
-    const ::embedding::EmbeddingBatchRequest &request,
-    ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::EmbeddingBatchResponse>::Create(channel_.get(), cq,
-                                                   rpcmethod_GetEmbeddings_,
-                                                   context, request, false);
+::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>* EmbeddingService::Stub::PrepareAsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::EmbeddingBatchResponse>::Create(channel_.get(), cq, rpcmethod_GetEmbeddings_, context, request, false);
 }
 
-::grpc::Status
-EmbeddingService::Stub::Info(::grpc::ClientContext *context,
-                             const ::google::protobuf::Empty &request,
-                             ::embedding::InfoResponse *response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Info_,
-                                             context, request, response);
+::grpc::Status EmbeddingService::Stub::Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::embedding::RerankResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Rerank_, context, request, response);
 }
 
-void EmbeddingService::Stub::experimental_async::Info(
-    ::grpc::ClientContext *context, const ::google::protobuf::Empty *request,
-    ::embedding::InfoResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(),
-                                           stub_->rpcmethod_Info_, context,
-                                           request, response, std::move(f));
+void EmbeddingService::Stub::experimental_async::Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Rerank_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::Info(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::InfoResponse *response,
-    std::function<void(::grpc::Status)> f) {
-  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(),
-                                           stub_->rpcmethod_Info_, context,
-                                           request, response, std::move(f));
+void EmbeddingService::Stub::experimental_async::Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Rerank_, context, request, response, std::move(f));
 }
 
-void EmbeddingService::Stub::experimental_async::Info(
-    ::grpc::ClientContext *context, const ::google::protobuf::Empty *request,
-    ::embedding::InfoResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response,
-      reactor);
+void EmbeddingService::Stub::experimental_async::Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Rerank_, context, request, response, reactor);
 }
 
-void EmbeddingService::Stub::experimental_async::Info(
-    ::grpc::ClientContext *context, const ::grpc::ByteBuffer *request,
-    ::embedding::InfoResponse *response,
-    ::grpc::experimental::ClientUnaryReactor *reactor) {
-  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(
-      stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response,
-      reactor);
+void EmbeddingService::Stub::experimental_async::Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Rerank_, context, request, response, reactor);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::InfoResponse> *
-EmbeddingService::Stub::AsyncInfoRaw(::grpc::ClientContext *context,
-                                     const ::google::protobuf::Empty &request,
-                                     ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::InfoResponse>::Create(channel_.get(), cq, rpcmethod_Info_,
-                                         context, request, true);
+::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>* EmbeddingService::Stub::AsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::RerankResponse>::Create(channel_.get(), cq, rpcmethod_Rerank_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader<::embedding::InfoResponse> *
-EmbeddingService::Stub::PrepareAsyncInfoRaw(
-    ::grpc::ClientContext *context, const ::google::protobuf::Empty &request,
-    ::grpc::CompletionQueue *cq) {
-  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory<
-      ::embedding::InfoResponse>::Create(channel_.get(), cq, rpcmethod_Info_,
-                                         context, request, false);
+::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>* EmbeddingService::Stub::PrepareAsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::RerankResponse>::Create(channel_.get(), cq, rpcmethod_Rerank_, context, request, false);
+}
+
+::grpc::Status EmbeddingService::Stub::Info(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::embedding::InfoResponse* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Info_, context, request, response);
+}
+
+void EmbeddingService::Stub::experimental_async::Info(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response, std::move(f));
+}
+
+void EmbeddingService::Stub::experimental_async::Info(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)> f) {
+  ::grpc_impl::internal::CallbackUnaryCall(stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response, std::move(f));
+}
+
+void EmbeddingService::Stub::experimental_async::Info(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response, reactor);
+}
+
+void EmbeddingService::Stub::experimental_async::Info(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::InfoResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) {
+  ::grpc_impl::internal::ClientCallbackUnaryFactory::Create(stub_->channel_.get(), stub_->rpcmethod_Info_, context, request, response, reactor);
+}
+
+::grpc::ClientAsyncResponseReader< ::embedding::InfoResponse>* EmbeddingService::Stub::AsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::InfoResponse>::Create(channel_.get(), cq, rpcmethod_Info_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::embedding::InfoResponse>* EmbeddingService::Stub::PrepareAsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc_impl::internal::ClientAsyncResponseReaderFactory< ::embedding::InfoResponse>::Create(channel_.get(), cq, rpcmethod_Info_, context, request, false);
 }
 
 EmbeddingService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      EmbeddingService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler<EmbeddingService::Service,
-                                             ::embedding::EmbeddingRequest,
-                                             ::embedding::EmbeddingResponse>(
-          [](EmbeddingService::Service *service,
-             ::grpc_impl::ServerContext *ctx,
-             const ::embedding::EmbeddingRequest *req,
-             ::embedding::EmbeddingResponse *resp) {
-            return service->GetEmbedding(ctx, req, resp);
-          },
-          this)));
+      EmbeddingService_method_names[0],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< EmbeddingService::Service, ::embedding::EmbeddingRequest, ::embedding::EmbeddingResponse>(
+          [](EmbeddingService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::embedding::EmbeddingRequest* req,
+             ::embedding::EmbeddingResponse* resp) {
+               return service->GetEmbedding(ctx, req, resp);
+             }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      EmbeddingService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler<
-          EmbeddingService::Service, ::embedding::EmbeddingBatchRequest,
-          ::embedding::EmbeddingBatchResponse>(
-          [](EmbeddingService::Service *service,
-             ::grpc_impl::ServerContext *ctx,
-             const ::embedding::EmbeddingBatchRequest *req,
-             ::embedding::EmbeddingBatchResponse *resp) {
-            return service->GetEmbeddings(ctx, req, resp);
-          },
-          this)));
+      EmbeddingService_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< EmbeddingService::Service, ::embedding::EmbeddingBatchRequest, ::embedding::EmbeddingBatchResponse>(
+          [](EmbeddingService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::embedding::EmbeddingBatchRequest* req,
+             ::embedding::EmbeddingBatchResponse* resp) {
+               return service->GetEmbeddings(ctx, req, resp);
+             }, this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      EmbeddingService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler<EmbeddingService::Service,
-                                             ::google::protobuf::Empty,
-                                             ::embedding::InfoResponse>(
-          [](EmbeddingService::Service *service,
-             ::grpc_impl::ServerContext *ctx,
-             const ::google::protobuf::Empty *req,
-             ::embedding::InfoResponse *resp) {
-            return service->Info(ctx, req, resp);
-          },
-          this)));
+      EmbeddingService_method_names[2],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< EmbeddingService::Service, ::embedding::RerankRequest, ::embedding::RerankResponse>(
+          [](EmbeddingService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::embedding::RerankRequest* req,
+             ::embedding::RerankResponse* resp) {
+               return service->Rerank(ctx, req, resp);
+             }, this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      EmbeddingService_method_names[3],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< EmbeddingService::Service, ::google::protobuf::Empty, ::embedding::InfoResponse>(
+          [](EmbeddingService::Service* service,
+             ::grpc_impl::ServerContext* ctx,
+             const ::google::protobuf::Empty* req,
+             ::embedding::InfoResponse* resp) {
+               return service->Info(ctx, req, resp);
+             }, this)));
 }
 
-EmbeddingService::Service::~Service() {}
+EmbeddingService::Service::~Service() {
+}
 
-::grpc::Status EmbeddingService::Service::GetEmbedding(
-    ::grpc::ServerContext *context,
-    const ::embedding::EmbeddingRequest *request,
-    ::embedding::EmbeddingResponse *response) {
-  (void)context;
-  (void)request;
-  (void)response;
+::grpc::Status EmbeddingService::Service::GetEmbedding(::grpc::ServerContext* context, const ::embedding::EmbeddingRequest* request, ::embedding::EmbeddingResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status EmbeddingService::Service::GetEmbeddings(
-    ::grpc::ServerContext *context,
-    const ::embedding::EmbeddingBatchRequest *request,
-    ::embedding::EmbeddingBatchResponse *response) {
-  (void)context;
-  (void)request;
-  (void)response;
+::grpc::Status EmbeddingService::Service::GetEmbeddings(::grpc::ServerContext* context, const ::embedding::EmbeddingBatchRequest* request, ::embedding::EmbeddingBatchResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status
-EmbeddingService::Service::Info(::grpc::ServerContext *context,
-                                const ::google::protobuf::Empty *request,
-                                ::embedding::InfoResponse *response) {
-  (void)context;
-  (void)request;
-  (void)response;
+::grpc::Status EmbeddingService::Service::Rerank(::grpc::ServerContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-} // namespace embedding
+::grpc::Status EmbeddingService::Service::Info(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+
+}  // namespace embedding
+

--- a/local_embedding_service/generated/embedding.grpc.pb.h
+++ b/local_embedding_service/generated/embedding.grpc.pb.h
@@ -50,6 +50,13 @@ class EmbeddingService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::EmbeddingBatchResponse>> PrepareAsyncGetEmbeddings(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::EmbeddingBatchResponse>>(PrepareAsyncGetEmbeddingsRaw(context, request, cq));
     }
+    virtual ::grpc::Status Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::embedding::RerankResponse* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>> AsyncRerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>>(AsyncRerankRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>> PrepareAsyncRerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>>(PrepareAsyncRerankRaw(context, request, cq));
+    }
     virtual ::grpc::Status Info(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::embedding::InfoResponse* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::InfoResponse>> AsyncInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::embedding::InfoResponse>>(AsyncInfoRaw(context, request, cq));
@@ -84,6 +91,18 @@ class EmbeddingService final {
       #else
       virtual void GetEmbeddings(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingBatchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
       #endif
+      virtual void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)>) = 0;
+      virtual void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)>) = 0;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      virtual void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, ::grpc::ClientUnaryReactor* reactor) = 0;
+      #else
+      virtual void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) = 0;
+      #endif
       virtual void Info(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)>) = 0;
       virtual void Info(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)>) = 0;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -109,6 +128,8 @@ class EmbeddingService final {
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::EmbeddingResponse>* PrepareAsyncGetEmbeddingRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::EmbeddingBatchResponse>* AsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::EmbeddingBatchResponse>* PrepareAsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>* AsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::RerankResponse>* PrepareAsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::InfoResponse>* AsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::embedding::InfoResponse>* PrepareAsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) = 0;
   };
@@ -128,6 +149,13 @@ class EmbeddingService final {
     }
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>> PrepareAsyncGetEmbeddings(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>>(PrepareAsyncGetEmbeddingsRaw(context, request, cq));
+    }
+    ::grpc::Status Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::embedding::RerankResponse* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>> AsyncRerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>>(AsyncRerankRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>> PrepareAsyncRerank(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>>(PrepareAsyncRerankRaw(context, request, cq));
     }
     ::grpc::Status Info(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::embedding::InfoResponse* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::embedding::InfoResponse>> AsyncInfo(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) {
@@ -163,6 +191,18 @@ class EmbeddingService final {
       #else
       void GetEmbeddings(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::EmbeddingBatchResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
       #endif
+      void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)>) override;
+      void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, std::function<void(::grpc::Status)>) override;
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void Rerank(::grpc::ClientContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
+      #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, ::grpc::ClientUnaryReactor* reactor) override;
+      #else
+      void Rerank(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::RerankResponse* response, ::grpc::experimental::ClientUnaryReactor* reactor) override;
+      #endif
       void Info(::grpc::ClientContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)>) override;
       void Info(::grpc::ClientContext* context, const ::grpc::ByteBuffer* request, ::embedding::InfoResponse* response, std::function<void(::grpc::Status)>) override;
       #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -190,10 +230,13 @@ class EmbeddingService final {
     ::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingResponse>* PrepareAsyncGetEmbeddingRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>* AsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::embedding::EmbeddingBatchResponse>* PrepareAsyncGetEmbeddingsRaw(::grpc::ClientContext* context, const ::embedding::EmbeddingBatchRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>* AsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::embedding::RerankResponse>* PrepareAsyncRerankRaw(::grpc::ClientContext* context, const ::embedding::RerankRequest& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::embedding::InfoResponse>* AsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::embedding::InfoResponse>* PrepareAsyncInfoRaw(::grpc::ClientContext* context, const ::google::protobuf::Empty& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_GetEmbedding_;
     const ::grpc::internal::RpcMethod rpcmethod_GetEmbeddings_;
+    const ::grpc::internal::RpcMethod rpcmethod_Rerank_;
     const ::grpc::internal::RpcMethod rpcmethod_Info_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
@@ -204,6 +247,7 @@ class EmbeddingService final {
     virtual ~Service();
     virtual ::grpc::Status GetEmbedding(::grpc::ServerContext* context, const ::embedding::EmbeddingRequest* request, ::embedding::EmbeddingResponse* response);
     virtual ::grpc::Status GetEmbeddings(::grpc::ServerContext* context, const ::embedding::EmbeddingBatchRequest* request, ::embedding::EmbeddingBatchResponse* response);
+    virtual ::grpc::Status Rerank(::grpc::ServerContext* context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response);
     virtual ::grpc::Status Info(::grpc::ServerContext* context, const ::google::protobuf::Empty* request, ::embedding::InfoResponse* response);
   };
   template <class BaseClass>
@@ -247,12 +291,32 @@ class EmbeddingService final {
     }
   };
   template <class BaseClass>
+  class WithAsyncMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithAsyncMethod_Rerank() {
+      ::grpc::Service::MarkMethodAsync(2);
+    }
+    ~WithAsyncMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRerank(::grpc::ServerContext* context, ::embedding::RerankRequest* request, ::grpc::ServerAsyncResponseWriter< ::embedding::RerankResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithAsyncMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithAsyncMethod_Info() {
-      ::grpc::Service::MarkMethodAsync(2);
+      ::grpc::Service::MarkMethodAsync(3);
     }
     ~WithAsyncMethod_Info() override {
       BaseClassMustBeDerivedFromService(this);
@@ -263,10 +327,10 @@ class EmbeddingService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInfo(::grpc::ServerContext* context, ::google::protobuf::Empty* request, ::grpc::ServerAsyncResponseWriter< ::embedding::InfoResponse>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_GetEmbedding<WithAsyncMethod_GetEmbeddings<WithAsyncMethod_Info<Service > > > AsyncService;
+  typedef WithAsyncMethod_GetEmbedding<WithAsyncMethod_GetEmbeddings<WithAsyncMethod_Rerank<WithAsyncMethod_Info<Service > > > > AsyncService;
   template <class BaseClass>
   class ExperimentalWithCallbackMethod_GetEmbedding : public BaseClass {
    private:
@@ -362,6 +426,53 @@ class EmbeddingService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithCallbackMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithCallbackMethod_Rerank() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodCallback(2,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::embedding::RerankRequest, ::embedding::RerankResponse>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::embedding::RerankRequest* request, ::embedding::RerankResponse* response) { return this->Rerank(context, request, response); }));}
+    void SetMessageAllocatorFor_Rerank(
+        ::grpc::experimental::MessageAllocator< ::embedding::RerankRequest, ::embedding::RerankResponse>* allocator) {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+    #else
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(2);
+    #endif
+      static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::embedding::RerankRequest, ::embedding::RerankResponse>*>(handler)
+              ->SetMessageAllocator(allocator);
+    }
+    ~ExperimentalWithCallbackMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* Rerank(
+      ::grpc::CallbackServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* Rerank(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithCallbackMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -372,7 +483,7 @@ class EmbeddingService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodCallback(2,
+        MarkMethodCallback(3,
           new ::grpc_impl::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::embedding::InfoResponse>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -384,9 +495,9 @@ class EmbeddingService final {
     void SetMessageAllocatorFor_Info(
         ::grpc::experimental::MessageAllocator< ::google::protobuf::Empty, ::embedding::InfoResponse>* allocator) {
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::GetHandler(3);
     #else
-      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(2);
+      ::grpc::internal::MethodHandler* const handler = ::grpc::Service::experimental().GetHandler(3);
     #endif
       static_cast<::grpc_impl::internal::CallbackUnaryHandler< ::google::protobuf::Empty, ::embedding::InfoResponse>*>(handler)
               ->SetMessageAllocator(allocator);
@@ -409,10 +520,10 @@ class EmbeddingService final {
       { return nullptr; }
   };
   #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
-  typedef ExperimentalWithCallbackMethod_GetEmbedding<ExperimentalWithCallbackMethod_GetEmbeddings<ExperimentalWithCallbackMethod_Info<Service > > > CallbackService;
+  typedef ExperimentalWithCallbackMethod_GetEmbedding<ExperimentalWithCallbackMethod_GetEmbeddings<ExperimentalWithCallbackMethod_Rerank<ExperimentalWithCallbackMethod_Info<Service > > > > CallbackService;
   #endif
 
-  typedef ExperimentalWithCallbackMethod_GetEmbedding<ExperimentalWithCallbackMethod_GetEmbeddings<ExperimentalWithCallbackMethod_Info<Service > > > ExperimentalCallbackService;
+  typedef ExperimentalWithCallbackMethod_GetEmbedding<ExperimentalWithCallbackMethod_GetEmbeddings<ExperimentalWithCallbackMethod_Rerank<ExperimentalWithCallbackMethod_Info<Service > > > > ExperimentalCallbackService;
   template <class BaseClass>
   class WithGenericMethod_GetEmbedding : public BaseClass {
    private:
@@ -448,12 +559,29 @@ class EmbeddingService final {
     }
   };
   template <class BaseClass>
+  class WithGenericMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithGenericMethod_Rerank() {
+      ::grpc::Service::MarkMethodGeneric(2);
+    }
+    ~WithGenericMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
   class WithGenericMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithGenericMethod_Info() {
-      ::grpc::Service::MarkMethodGeneric(2);
+      ::grpc::Service::MarkMethodGeneric(3);
     }
     ~WithGenericMethod_Info() override {
       BaseClassMustBeDerivedFromService(this);
@@ -505,12 +633,32 @@ class EmbeddingService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithRawMethod_Rerank() {
+      ::grpc::Service::MarkMethodRaw(2);
+    }
+    ~WithRawMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestRerank(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithRawMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithRawMethod_Info() {
-      ::grpc::Service::MarkMethodRaw(2);
+      ::grpc::Service::MarkMethodRaw(3);
     }
     ~WithRawMethod_Info() override {
       BaseClassMustBeDerivedFromService(this);
@@ -521,7 +669,7 @@ class EmbeddingService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestInfo(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -601,6 +749,44 @@ class EmbeddingService final {
       { return nullptr; }
   };
   template <class BaseClass>
+  class ExperimentalWithRawCallbackMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    ExperimentalWithRawCallbackMethod_Rerank() {
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+      ::grpc::Service::
+    #else
+      ::grpc::Service::experimental().
+    #endif
+        MarkMethodRawCallback(2,
+          new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
+            [this](
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+                   ::grpc::CallbackServerContext*
+    #else
+                   ::grpc::experimental::CallbackServerContext*
+    #endif
+                     context, const ::grpc::ByteBuffer* request, ::grpc::ByteBuffer* response) { return this->Rerank(context, request, response); }));
+    }
+    ~ExperimentalWithRawCallbackMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
+    virtual ::grpc::ServerUnaryReactor* Rerank(
+      ::grpc::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #else
+    virtual ::grpc::experimental::ServerUnaryReactor* Rerank(
+      ::grpc::experimental::CallbackServerContext* /*context*/, const ::grpc::ByteBuffer* /*request*/, ::grpc::ByteBuffer* /*response*/)
+    #endif
+      { return nullptr; }
+  };
+  template <class BaseClass>
   class ExperimentalWithRawCallbackMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
@@ -611,7 +797,7 @@ class EmbeddingService final {
     #else
       ::grpc::Service::experimental().
     #endif
-        MarkMethodRawCallback(2,
+        MarkMethodRawCallback(3,
           new ::grpc_impl::internal::CallbackUnaryHandler< ::grpc::ByteBuffer, ::grpc::ByteBuffer>(
             [this](
     #ifdef GRPC_CALLBACK_API_NONEXPERIMENTAL
@@ -693,12 +879,39 @@ class EmbeddingService final {
     virtual ::grpc::Status StreamedGetEmbeddings(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::embedding::EmbeddingBatchRequest,::embedding::EmbeddingBatchResponse>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
+  class WithStreamedUnaryMethod_Rerank : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
+   public:
+    WithStreamedUnaryMethod_Rerank() {
+      ::grpc::Service::MarkMethodStreamed(2,
+        new ::grpc::internal::StreamedUnaryHandler<
+          ::embedding::RerankRequest, ::embedding::RerankResponse>(
+            [this](::grpc_impl::ServerContext* context,
+                   ::grpc_impl::ServerUnaryStreamer<
+                     ::embedding::RerankRequest, ::embedding::RerankResponse>* streamer) {
+                       return this->StreamedRerank(context,
+                         streamer);
+                  }));
+    }
+    ~WithStreamedUnaryMethod_Rerank() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Rerank(::grpc::ServerContext* /*context*/, const ::embedding::RerankRequest* /*request*/, ::embedding::RerankResponse* /*response*/) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedRerank(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::embedding::RerankRequest,::embedding::RerankResponse>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_Info : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service* /*service*/) {}
    public:
     WithStreamedUnaryMethod_Info() {
-      ::grpc::Service::MarkMethodStreamed(2,
+      ::grpc::Service::MarkMethodStreamed(3,
         new ::grpc::internal::StreamedUnaryHandler<
           ::google::protobuf::Empty, ::embedding::InfoResponse>(
             [this](::grpc_impl::ServerContext* context,
@@ -719,9 +932,9 @@ class EmbeddingService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedInfo(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::google::protobuf::Empty,::embedding::InfoResponse>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_GetEmbedding<WithStreamedUnaryMethod_GetEmbeddings<WithStreamedUnaryMethod_Info<Service > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_GetEmbedding<WithStreamedUnaryMethod_GetEmbeddings<WithStreamedUnaryMethod_Rerank<WithStreamedUnaryMethod_Info<Service > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_GetEmbedding<WithStreamedUnaryMethod_GetEmbeddings<WithStreamedUnaryMethod_Info<Service > > > StreamedService;
+  typedef WithStreamedUnaryMethod_GetEmbedding<WithStreamedUnaryMethod_GetEmbeddings<WithStreamedUnaryMethod_Rerank<WithStreamedUnaryMethod_Info<Service > > > > StreamedService;
 };
 
 }  // namespace embedding

--- a/local_embedding_service/generated/embedding.pb.cc
+++ b/local_embedding_service/generated/embedding.pb.cc
@@ -15,6 +15,9 @@
 // @@protoc_insertion_point(includes)
 #include <google/protobuf/port_def.inc>
 extern PROTOBUF_INTERNAL_EXPORT_embedding_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_EmbeddingBatchItem_embedding_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_embedding_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_RerankItem_embedding_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_embedding_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_RerankQuery_embedding_2eproto;
+extern PROTOBUF_INTERNAL_EXPORT_embedding_2eproto ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_RerankResult_embedding_2eproto;
 namespace embedding {
 class EmbeddingRequestDefaultTypeInternal {
  public:
@@ -36,6 +39,26 @@ class EmbeddingBatchResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<EmbeddingBatchResponse> _instance;
 } _EmbeddingBatchResponse_default_instance_;
+class RerankQueryDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RerankQuery> _instance;
+} _RerankQuery_default_instance_;
+class RerankRequestDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RerankRequest> _instance;
+} _RerankRequest_default_instance_;
+class RerankItemDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RerankItem> _instance;
+} _RerankItem_default_instance_;
+class RerankResultDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RerankResult> _instance;
+} _RerankResult_default_instance_;
+class RerankResponseDefaultTypeInternal {
+ public:
+  ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<RerankResponse> _instance;
+} _RerankResponse_default_instance_;
 class InfoResponseDefaultTypeInternal {
  public:
   ::PROTOBUF_NAMESPACE_ID::internal::ExplicitlyConstructed<InfoResponse> _instance;
@@ -126,7 +149,80 @@ static void InitDefaultsscc_info_InfoResponse_embedding_2eproto() {
 ::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_InfoResponse_embedding_2eproto =
     {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_InfoResponse_embedding_2eproto}, {}};
 
-static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_embedding_2eproto[6];
+static void InitDefaultsscc_info_RerankItem_embedding_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::embedding::_RerankItem_default_instance_;
+    new (ptr) ::embedding::RerankItem();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::embedding::RerankItem::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_RerankItem_embedding_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_RerankItem_embedding_2eproto}, {}};
+
+static void InitDefaultsscc_info_RerankQuery_embedding_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::embedding::_RerankQuery_default_instance_;
+    new (ptr) ::embedding::RerankQuery();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::embedding::RerankQuery::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<0> scc_info_RerankQuery_embedding_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 0, 0, InitDefaultsscc_info_RerankQuery_embedding_2eproto}, {}};
+
+static void InitDefaultsscc_info_RerankRequest_embedding_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::embedding::_RerankRequest_default_instance_;
+    new (ptr) ::embedding::RerankRequest();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::embedding::RerankRequest::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_RerankRequest_embedding_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_RerankRequest_embedding_2eproto}, {
+      &scc_info_RerankQuery_embedding_2eproto.base,}};
+
+static void InitDefaultsscc_info_RerankResponse_embedding_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::embedding::_RerankResponse_default_instance_;
+    new (ptr) ::embedding::RerankResponse();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::embedding::RerankResponse::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_RerankResponse_embedding_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_RerankResponse_embedding_2eproto}, {
+      &scc_info_RerankResult_embedding_2eproto.base,}};
+
+static void InitDefaultsscc_info_RerankResult_embedding_2eproto() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::embedding::_RerankResult_default_instance_;
+    new (ptr) ::embedding::RerankResult();
+    ::PROTOBUF_NAMESPACE_ID::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::embedding::RerankResult::InitAsDefaultInstance();
+}
+
+::PROTOBUF_NAMESPACE_ID::internal::SCCInfo<1> scc_info_RerankResult_embedding_2eproto =
+    {{ATOMIC_VAR_INIT(::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase::kUninitialized), 1, 0, InitDefaultsscc_info_RerankResult_embedding_2eproto}, {
+      &scc_info_RerankItem_embedding_2eproto.base,}};
+
+static ::PROTOBUF_NAMESPACE_ID::Metadata file_level_metadata_embedding_2eproto[11];
 static constexpr ::PROTOBUF_NAMESPACE_ID::EnumDescriptor const** file_level_enum_descriptors_embedding_2eproto = nullptr;
 static constexpr ::PROTOBUF_NAMESPACE_ID::ServiceDescriptor const** file_level_service_descriptors_embedding_2eproto = nullptr;
 
@@ -165,6 +261,42 @@ const ::PROTOBUF_NAMESPACE_ID::uint32 TableStruct_embedding_2eproto::offsets[] P
   PROTOBUF_FIELD_OFFSET(::embedding::EmbeddingBatchResponse, items_),
   PROTOBUF_FIELD_OFFSET(::embedding::EmbeddingBatchResponse, error_),
   ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankQuery, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankQuery, query_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankQuery, documents_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankQuery, top_k_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankRequest, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankRequest, queries_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankItem, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankItem, index_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankItem, document_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankItem, score_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResult, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResult, items_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResult, error_),
+  ~0u,  // no _has_bits_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResponse, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResponse, results_),
+  PROTOBUF_FIELD_OFFSET(::embedding::RerankResponse, error_),
+  ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::embedding::InfoResponse, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
@@ -179,7 +311,12 @@ static const ::PROTOBUF_NAMESPACE_ID::internal::MigrationSchema schemas[] PROTOB
   { 13, -1, sizeof(::embedding::EmbeddingBatchRequest)},
   { 19, -1, sizeof(::embedding::EmbeddingBatchItem)},
   { 26, -1, sizeof(::embedding::EmbeddingBatchResponse)},
-  { 33, -1, sizeof(::embedding::InfoResponse)},
+  { 33, -1, sizeof(::embedding::RerankQuery)},
+  { 41, -1, sizeof(::embedding::RerankRequest)},
+  { 47, -1, sizeof(::embedding::RerankItem)},
+  { 55, -1, sizeof(::embedding::RerankResult)},
+  { 62, -1, sizeof(::embedding::RerankResponse)},
+  { 69, -1, sizeof(::embedding::InfoResponse)},
 };
 
 static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] = {
@@ -188,6 +325,11 @@ static ::PROTOBUF_NAMESPACE_ID::Message const * const file_default_instances[] =
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_EmbeddingBatchRequest_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_EmbeddingBatchItem_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_EmbeddingBatchResponse_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_RerankQuery_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_RerankRequest_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_RerankItem_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_RerankResult_default_instance_),
+  reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_RerankResponse_default_instance_),
   reinterpret_cast<const ::PROTOBUF_NAMESPACE_ID::Message*>(&::embedding::_InfoResponse_default_instance_),
 };
 
@@ -200,33 +342,48 @@ const char descriptor_table_protodef_embedding_2eproto[] PROTOBUF_SECTION_VARIAB
   "atchItem\022\021\n\tembedding\030\001 \003(\002\022\r\n\005error\030\002 \001"
   "(\t\"U\n\026EmbeddingBatchResponse\022,\n\005items\030\001 "
   "\003(\0132\035.embedding.EmbeddingBatchItem\022\r\n\005er"
-  "ror\030\002 \001(\t\"C\n\014InfoResponse\022\020\n\010provider\030\001 "
-  "\001(\t\022\r\n\005model\030\002 \001(\t\022\022\n\ndimensions\030\003 \001(\0052\354"
-  "\001\n\020EmbeddingService\022I\n\014GetEmbedding\022\033.em"
-  "bedding.EmbeddingRequest\032\034.embedding.Emb"
-  "eddingResponse\022T\n\rGetEmbeddings\022 .embedd"
-  "ing.EmbeddingBatchRequest\032!.embedding.Em"
-  "beddingBatchResponse\0227\n\004Info\022\026.google.pr"
-  "otobuf.Empty\032\027.embedding.InfoResponseB\003\370"
-  "\001\001b\006proto3"
+  "ror\030\002 \001(\t\">\n\013RerankQuery\022\r\n\005query\030\001 \001(\t\022"
+  "\021\n\tdocuments\030\002 \003(\t\022\r\n\005top_k\030\003 \001(\005\"8\n\rRer"
+  "ankRequest\022\'\n\007queries\030\001 \003(\0132\026.embedding."
+  "RerankQuery\"<\n\nRerankItem\022\r\n\005index\030\001 \001(\005"
+  "\022\020\n\010document\030\002 \001(\t\022\r\n\005score\030\003 \001(\002\"C\n\014Rer"
+  "ankResult\022$\n\005items\030\001 \003(\0132\025.embedding.Rer"
+  "ankItem\022\r\n\005error\030\002 \001(\t\"I\n\016RerankResponse"
+  "\022(\n\007results\030\001 \003(\0132\027.embedding.RerankResu"
+  "lt\022\r\n\005error\030\002 \001(\t\"C\n\014InfoResponse\022\020\n\010pro"
+  "vider\030\001 \001(\t\022\r\n\005model\030\002 \001(\t\022\022\n\ndimensions"
+  "\030\003 \001(\0052\253\002\n\020EmbeddingService\022I\n\014GetEmbedd"
+  "ing\022\033.embedding.EmbeddingRequest\032\034.embed"
+  "ding.EmbeddingResponse\022T\n\rGetEmbeddings\022"
+  " .embedding.EmbeddingBatchRequest\032!.embe"
+  "dding.EmbeddingBatchResponse\022=\n\006Rerank\022\030"
+  ".embedding.RerankRequest\032\031.embedding.Rer"
+  "ankResponse\0227\n\004Info\022\026.google.protobuf.Em"
+  "pty\032\027.embedding.InfoResponseB\003\370\001\001b\006proto"
+  "3"
   ;
 static const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable*const descriptor_table_embedding_2eproto_deps[1] = {
   &::descriptor_table_google_2fprotobuf_2fempty_2eproto,
 };
-static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_embedding_2eproto_sccs[6] = {
+static ::PROTOBUF_NAMESPACE_ID::internal::SCCInfoBase*const descriptor_table_embedding_2eproto_sccs[11] = {
   &scc_info_EmbeddingBatchItem_embedding_2eproto.base,
   &scc_info_EmbeddingBatchRequest_embedding_2eproto.base,
   &scc_info_EmbeddingBatchResponse_embedding_2eproto.base,
   &scc_info_EmbeddingRequest_embedding_2eproto.base,
   &scc_info_EmbeddingResponse_embedding_2eproto.base,
   &scc_info_InfoResponse_embedding_2eproto.base,
+  &scc_info_RerankItem_embedding_2eproto.base,
+  &scc_info_RerankQuery_embedding_2eproto.base,
+  &scc_info_RerankRequest_embedding_2eproto.base,
+  &scc_info_RerankResponse_embedding_2eproto.base,
+  &scc_info_RerankResult_embedding_2eproto.base,
 };
 static ::PROTOBUF_NAMESPACE_ID::internal::once_flag descriptor_table_embedding_2eproto_once;
 const ::PROTOBUF_NAMESPACE_ID::internal::DescriptorTable descriptor_table_embedding_2eproto = {
-  false, false, descriptor_table_protodef_embedding_2eproto, "embedding.proto", 650,
-  &descriptor_table_embedding_2eproto_once, descriptor_table_embedding_2eproto_sccs, descriptor_table_embedding_2eproto_deps, 6, 1,
+  false, false, descriptor_table_protodef_embedding_2eproto, "embedding.proto", 1041,
+  &descriptor_table_embedding_2eproto_once, descriptor_table_embedding_2eproto_sccs, descriptor_table_embedding_2eproto_deps, 11, 1,
   schemas, file_default_instances, TableStruct_embedding_2eproto::offsets,
-  file_level_metadata_embedding_2eproto, 6, file_level_enum_descriptors_embedding_2eproto, file_level_service_descriptors_embedding_2eproto,
+  file_level_metadata_embedding_2eproto, 11, file_level_enum_descriptors_embedding_2eproto, file_level_service_descriptors_embedding_2eproto,
 };
 
 // Force running AddDescriptors() at dynamic initialization time.
@@ -1381,6 +1538,1232 @@ void EmbeddingBatchResponse::InternalSwap(EmbeddingBatchResponse* other) {
 
 // ===================================================================
 
+void RerankQuery::InitAsDefaultInstance() {
+}
+class RerankQuery::_Internal {
+ public:
+};
+
+RerankQuery::RerankQuery(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  documents_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:embedding.RerankQuery)
+}
+RerankQuery::RerankQuery(const RerankQuery& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      documents_(from.documents_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  query_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_query().empty()) {
+    query_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_query(),
+      GetArena());
+  }
+  top_k_ = from.top_k_;
+  // @@protoc_insertion_point(copy_constructor:embedding.RerankQuery)
+}
+
+void RerankQuery::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_RerankQuery_embedding_2eproto.base);
+  query_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  top_k_ = 0;
+}
+
+RerankQuery::~RerankQuery() {
+  // @@protoc_insertion_point(destructor:embedding.RerankQuery)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void RerankQuery::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  query_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void RerankQuery::ArenaDtor(void* object) {
+  RerankQuery* _this = reinterpret_cast< RerankQuery* >(object);
+  (void)_this;
+}
+void RerankQuery::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void RerankQuery::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const RerankQuery& RerankQuery::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_RerankQuery_embedding_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void RerankQuery::Clear() {
+// @@protoc_insertion_point(message_clear_start:embedding.RerankQuery)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  documents_.Clear();
+  query_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  top_k_ = 0;
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RerankQuery::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // string query = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          auto str = _internal_mutable_query();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "embedding.RerankQuery.query"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // repeated string documents = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            auto str = _internal_add_documents();
+            ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+            CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "embedding.RerankQuery.documents"));
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<18>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // int32 top_k = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 24)) {
+          top_k_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* RerankQuery::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:embedding.RerankQuery)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string query = 1;
+  if (this->query().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_query().data(), static_cast<int>(this->_internal_query().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "embedding.RerankQuery.query");
+    target = stream->WriteStringMaybeAliased(
+        1, this->_internal_query(), target);
+  }
+
+  // repeated string documents = 2;
+  for (int i = 0, n = this->_internal_documents_size(); i < n; i++) {
+    const auto& s = this->_internal_documents(i);
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      s.data(), static_cast<int>(s.length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "embedding.RerankQuery.documents");
+    target = stream->WriteString(2, s, target);
+  }
+
+  // int32 top_k = 3;
+  if (this->top_k() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(3, this->_internal_top_k(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:embedding.RerankQuery)
+  return target;
+}
+
+size_t RerankQuery::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:embedding.RerankQuery)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated string documents = 2;
+  total_size += 1 *
+      ::PROTOBUF_NAMESPACE_ID::internal::FromIntSize(documents_.size());
+  for (int i = 0, n = documents_.size(); i < n; i++) {
+    total_size += ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+      documents_.Get(i));
+  }
+
+  // string query = 1;
+  if (this->query().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_query());
+  }
+
+  // int32 top_k = 3;
+  if (this->top_k() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_top_k());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RerankQuery::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:embedding.RerankQuery)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RerankQuery* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<RerankQuery>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:embedding.RerankQuery)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:embedding.RerankQuery)
+    MergeFrom(*source);
+  }
+}
+
+void RerankQuery::MergeFrom(const RerankQuery& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:embedding.RerankQuery)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  documents_.MergeFrom(from.documents_);
+  if (from.query().size() > 0) {
+    _internal_set_query(from._internal_query());
+  }
+  if (from.top_k() != 0) {
+    _internal_set_top_k(from._internal_top_k());
+  }
+}
+
+void RerankQuery::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:embedding.RerankQuery)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RerankQuery::CopyFrom(const RerankQuery& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:embedding.RerankQuery)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RerankQuery::IsInitialized() const {
+  return true;
+}
+
+void RerankQuery::InternalSwap(RerankQuery* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  documents_.InternalSwap(&other->documents_);
+  query_.Swap(&other->query_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  swap(top_k_, other->top_k_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RerankQuery::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void RerankRequest::InitAsDefaultInstance() {
+}
+class RerankRequest::_Internal {
+ public:
+};
+
+RerankRequest::RerankRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  queries_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:embedding.RerankRequest)
+}
+RerankRequest::RerankRequest(const RerankRequest& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      queries_(from.queries_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:embedding.RerankRequest)
+}
+
+void RerankRequest::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_RerankRequest_embedding_2eproto.base);
+}
+
+RerankRequest::~RerankRequest() {
+  // @@protoc_insertion_point(destructor:embedding.RerankRequest)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void RerankRequest::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+}
+
+void RerankRequest::ArenaDtor(void* object) {
+  RerankRequest* _this = reinterpret_cast< RerankRequest* >(object);
+  (void)_this;
+}
+void RerankRequest::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void RerankRequest::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const RerankRequest& RerankRequest::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_RerankRequest_embedding_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void RerankRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:embedding.RerankRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  queries_.Clear();
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RerankRequest::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated .embedding.RerankQuery queries = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_queries(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* RerankRequest::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:embedding.RerankRequest)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankQuery queries = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_queries_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, this->_internal_queries(i), target, stream);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:embedding.RerankRequest)
+  return target;
+}
+
+size_t RerankRequest::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:embedding.RerankRequest)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankQuery queries = 1;
+  total_size += 1UL * this->_internal_queries_size();
+  for (const auto& msg : this->queries_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RerankRequest::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:embedding.RerankRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RerankRequest* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<RerankRequest>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:embedding.RerankRequest)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:embedding.RerankRequest)
+    MergeFrom(*source);
+  }
+}
+
+void RerankRequest::MergeFrom(const RerankRequest& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:embedding.RerankRequest)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  queries_.MergeFrom(from.queries_);
+}
+
+void RerankRequest::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:embedding.RerankRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RerankRequest::CopyFrom(const RerankRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:embedding.RerankRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RerankRequest::IsInitialized() const {
+  return true;
+}
+
+void RerankRequest::InternalSwap(RerankRequest* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  queries_.InternalSwap(&other->queries_);
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RerankRequest::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void RerankItem::InitAsDefaultInstance() {
+}
+class RerankItem::_Internal {
+ public:
+};
+
+RerankItem::RerankItem(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:embedding.RerankItem)
+}
+RerankItem::RerankItem(const RerankItem& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message() {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  document_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_document().empty()) {
+    document_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_document(),
+      GetArena());
+  }
+  ::memcpy(&index_, &from.index_,
+    static_cast<size_t>(reinterpret_cast<char*>(&score_) -
+    reinterpret_cast<char*>(&index_)) + sizeof(score_));
+  // @@protoc_insertion_point(copy_constructor:embedding.RerankItem)
+}
+
+void RerankItem::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_RerankItem_embedding_2eproto.base);
+  document_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  ::memset(&index_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&score_) -
+      reinterpret_cast<char*>(&index_)) + sizeof(score_));
+}
+
+RerankItem::~RerankItem() {
+  // @@protoc_insertion_point(destructor:embedding.RerankItem)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void RerankItem::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  document_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void RerankItem::ArenaDtor(void* object) {
+  RerankItem* _this = reinterpret_cast< RerankItem* >(object);
+  (void)_this;
+}
+void RerankItem::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void RerankItem::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const RerankItem& RerankItem::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_RerankItem_embedding_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void RerankItem::Clear() {
+// @@protoc_insertion_point(message_clear_start:embedding.RerankItem)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  document_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::memset(&index_, 0, static_cast<size_t>(
+      reinterpret_cast<char*>(&score_) -
+      reinterpret_cast<char*>(&index_)) + sizeof(score_));
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RerankItem::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // int32 index = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 8)) {
+          index_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint64(&ptr);
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // string document = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_document();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "embedding.RerankItem.document"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      // float score = 3;
+      case 3:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 29)) {
+          score_ = ::PROTOBUF_NAMESPACE_ID::internal::UnalignedLoad<float>(ptr);
+          ptr += sizeof(float);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* RerankItem::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:embedding.RerankItem)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // int32 index = 1;
+  if (this->index() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteInt32ToArray(1, this->_internal_index(), target);
+  }
+
+  // string document = 2;
+  if (this->document().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_document().data(), static_cast<int>(this->_internal_document().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "embedding.RerankItem.document");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_document(), target);
+  }
+
+  // float score = 3;
+  if (!(this->score() <= 0 && this->score() >= 0)) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::WriteFloatToArray(3, this->_internal_score(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:embedding.RerankItem)
+  return target;
+}
+
+size_t RerankItem::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:embedding.RerankItem)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // string document = 2;
+  if (this->document().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_document());
+  }
+
+  // int32 index = 1;
+  if (this->index() != 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::Int32Size(
+        this->_internal_index());
+  }
+
+  // float score = 3;
+  if (!(this->score() <= 0 && this->score() >= 0)) {
+    total_size += 1 + 4;
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RerankItem::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:embedding.RerankItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RerankItem* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<RerankItem>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:embedding.RerankItem)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:embedding.RerankItem)
+    MergeFrom(*source);
+  }
+}
+
+void RerankItem::MergeFrom(const RerankItem& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:embedding.RerankItem)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.document().size() > 0) {
+    _internal_set_document(from._internal_document());
+  }
+  if (from.index() != 0) {
+    _internal_set_index(from._internal_index());
+  }
+  if (!(from.score() <= 0 && from.score() >= 0)) {
+    _internal_set_score(from._internal_score());
+  }
+}
+
+void RerankItem::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:embedding.RerankItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RerankItem::CopyFrom(const RerankItem& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:embedding.RerankItem)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RerankItem::IsInitialized() const {
+  return true;
+}
+
+void RerankItem::InternalSwap(RerankItem* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  document_.Swap(&other->document_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  ::PROTOBUF_NAMESPACE_ID::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(RerankItem, score_)
+      + sizeof(RerankItem::score_)
+      - PROTOBUF_FIELD_OFFSET(RerankItem, index_)>(
+          reinterpret_cast<char*>(&index_),
+          reinterpret_cast<char*>(&other->index_));
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RerankItem::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void RerankResult::InitAsDefaultInstance() {
+}
+class RerankResult::_Internal {
+ public:
+};
+
+RerankResult::RerankResult(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  items_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:embedding.RerankResult)
+}
+RerankResult::RerankResult(const RerankResult& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      items_(from.items_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  error_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_error().empty()) {
+    error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_error(),
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:embedding.RerankResult)
+}
+
+void RerankResult::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_RerankResult_embedding_2eproto.base);
+  error_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+RerankResult::~RerankResult() {
+  // @@protoc_insertion_point(destructor:embedding.RerankResult)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void RerankResult::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  error_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void RerankResult::ArenaDtor(void* object) {
+  RerankResult* _this = reinterpret_cast< RerankResult* >(object);
+  (void)_this;
+}
+void RerankResult::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void RerankResult::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const RerankResult& RerankResult::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_RerankResult_embedding_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void RerankResult::Clear() {
+// @@protoc_insertion_point(message_clear_start:embedding.RerankResult)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  items_.Clear();
+  error_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RerankResult::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated .embedding.RerankItem items = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_items(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "embedding.RerankResult.error"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* RerankResult::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:embedding.RerankResult)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankItem items = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_items_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, this->_internal_items(i), target, stream);
+  }
+
+  // string error = 2;
+  if (this->error().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "embedding.RerankResult.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:embedding.RerankResult)
+  return target;
+}
+
+size_t RerankResult::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:embedding.RerankResult)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankItem items = 1;
+  total_size += 1UL * this->_internal_items_size();
+  for (const auto& msg : this->items_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // string error = 2;
+  if (this->error().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_error());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RerankResult::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:embedding.RerankResult)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RerankResult* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<RerankResult>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:embedding.RerankResult)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:embedding.RerankResult)
+    MergeFrom(*source);
+  }
+}
+
+void RerankResult::MergeFrom(const RerankResult& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:embedding.RerankResult)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  items_.MergeFrom(from.items_);
+  if (from.error().size() > 0) {
+    _internal_set_error(from._internal_error());
+  }
+}
+
+void RerankResult::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:embedding.RerankResult)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RerankResult::CopyFrom(const RerankResult& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:embedding.RerankResult)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RerankResult::IsInitialized() const {
+  return true;
+}
+
+void RerankResult::InternalSwap(RerankResult* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  items_.InternalSwap(&other->items_);
+  error_.Swap(&other->error_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RerankResult::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
+void RerankResponse::InitAsDefaultInstance() {
+}
+class RerankResponse::_Internal {
+ public:
+};
+
+RerankResponse::RerankResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena)
+  : ::PROTOBUF_NAMESPACE_ID::Message(arena),
+  results_(arena) {
+  SharedCtor();
+  RegisterArenaDtor(arena);
+  // @@protoc_insertion_point(arena_constructor:embedding.RerankResponse)
+}
+RerankResponse::RerankResponse(const RerankResponse& from)
+  : ::PROTOBUF_NAMESPACE_ID::Message(),
+      results_(from.results_) {
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  error_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+  if (!from._internal_error().empty()) {
+    error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), from._internal_error(),
+      GetArena());
+  }
+  // @@protoc_insertion_point(copy_constructor:embedding.RerankResponse)
+}
+
+void RerankResponse::SharedCtor() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&scc_info_RerankResponse_embedding_2eproto.base);
+  error_.UnsafeSetDefault(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+RerankResponse::~RerankResponse() {
+  // @@protoc_insertion_point(destructor:embedding.RerankResponse)
+  SharedDtor();
+  _internal_metadata_.Delete<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+void RerankResponse::SharedDtor() {
+  GOOGLE_DCHECK(GetArena() == nullptr);
+  error_.DestroyNoArena(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited());
+}
+
+void RerankResponse::ArenaDtor(void* object) {
+  RerankResponse* _this = reinterpret_cast< RerankResponse* >(object);
+  (void)_this;
+}
+void RerankResponse::RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena*) {
+}
+void RerankResponse::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const RerankResponse& RerankResponse::default_instance() {
+  ::PROTOBUF_NAMESPACE_ID::internal::InitSCC(&::scc_info_RerankResponse_embedding_2eproto.base);
+  return *internal_default_instance();
+}
+
+
+void RerankResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:embedding.RerankResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  results_.Clear();
+  error_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+  _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
+}
+
+const char* RerankResponse::_InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) {
+#define CHK_(x) if (PROTOBUF_PREDICT_FALSE(!(x))) goto failure
+  ::PROTOBUF_NAMESPACE_ID::Arena* arena = GetArena(); (void)arena;
+  while (!ctx->Done(&ptr)) {
+    ::PROTOBUF_NAMESPACE_ID::uint32 tag;
+    ptr = ::PROTOBUF_NAMESPACE_ID::internal::ReadTag(ptr, &tag);
+    CHK_(ptr);
+    switch (tag >> 3) {
+      // repeated .embedding.RerankResult results = 1;
+      case 1:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 10)) {
+          ptr -= 1;
+          do {
+            ptr += 1;
+            ptr = ctx->ParseMessage(_internal_add_results(), ptr);
+            CHK_(ptr);
+            if (!ctx->DataAvailable(ptr)) break;
+          } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<10>(ptr));
+        } else goto handle_unusual;
+        continue;
+      // string error = 2;
+      case 2:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<::PROTOBUF_NAMESPACE_ID::uint8>(tag) == 18)) {
+          auto str = _internal_mutable_error();
+          ptr = ::PROTOBUF_NAMESPACE_ID::internal::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(::PROTOBUF_NAMESPACE_ID::internal::VerifyUTF8(str, "embedding.RerankResponse.error"));
+          CHK_(ptr);
+        } else goto handle_unusual;
+        continue;
+      default: {
+      handle_unusual:
+        if ((tag & 7) == 4 || tag == 0) {
+          ctx->SetLastTag(tag);
+          goto success;
+        }
+        ptr = UnknownFieldParse(tag,
+            _internal_metadata_.mutable_unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(),
+            ptr, ctx);
+        CHK_(ptr != nullptr);
+        continue;
+      }
+    }  // switch
+  }  // while
+success:
+  return ptr;
+failure:
+  ptr = nullptr;
+  goto success;
+#undef CHK_
+}
+
+::PROTOBUF_NAMESPACE_ID::uint8* RerankResponse::_InternalSerialize(
+    ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:embedding.RerankResponse)
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankResult results = 1;
+  for (unsigned int i = 0,
+      n = static_cast<unsigned int>(this->_internal_results_size()); i < n; i++) {
+    target = stream->EnsureSpace(target);
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::
+      InternalWriteMessage(1, this->_internal_results(i), target, stream);
+  }
+
+  // string error = 2;
+  if (this->error().size() > 0) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_error().data(), static_cast<int>(this->_internal_error().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "embedding.RerankResponse.error");
+    target = stream->WriteStringMaybeAliased(
+        2, this->_internal_error(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target = ::PROTOBUF_NAMESPACE_ID::internal::WireFormat::InternalSerializeUnknownFieldsToArray(
+        _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:embedding.RerankResponse)
+  return target;
+}
+
+size_t RerankResponse::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:embedding.RerankResponse)
+  size_t total_size = 0;
+
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // repeated .embedding.RerankResult results = 1;
+  total_size += 1UL * this->_internal_results_size();
+  for (const auto& msg : this->results_) {
+    total_size +=
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::MessageSize(msg);
+  }
+
+  // string error = 2;
+  if (this->error().size() > 0) {
+    total_size += 1 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_error());
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    return ::PROTOBUF_NAMESPACE_ID::internal::ComputeUnknownFieldsSize(
+        _internal_metadata_, total_size, &_cached_size_);
+  }
+  int cached_size = ::PROTOBUF_NAMESPACE_ID::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void RerankResponse::MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:embedding.RerankResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  const RerankResponse* source =
+      ::PROTOBUF_NAMESPACE_ID::DynamicCastToGenerated<RerankResponse>(
+          &from);
+  if (source == nullptr) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:embedding.RerankResponse)
+    ::PROTOBUF_NAMESPACE_ID::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:embedding.RerankResponse)
+    MergeFrom(*source);
+  }
+}
+
+void RerankResponse::MergeFrom(const RerankResponse& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:embedding.RerankResponse)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
+  ::PROTOBUF_NAMESPACE_ID::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  results_.MergeFrom(from.results_);
+  if (from.error().size() > 0) {
+    _internal_set_error(from._internal_error());
+  }
+}
+
+void RerankResponse::CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:embedding.RerankResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void RerankResponse::CopyFrom(const RerankResponse& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:embedding.RerankResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool RerankResponse::IsInitialized() const {
+  return true;
+}
+
+void RerankResponse::InternalSwap(RerankResponse* other) {
+  using std::swap;
+  _internal_metadata_.Swap<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(&other->_internal_metadata_);
+  results_.InternalSwap(&other->results_);
+  error_.Swap(&other->error_, &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+
+::PROTOBUF_NAMESPACE_ID::Metadata RerankResponse::GetMetadata() const {
+  return GetMetadataStatic();
+}
+
+
+// ===================================================================
+
 void InfoResponse::InitAsDefaultInstance() {
 }
 class InfoResponse::_Internal {
@@ -1670,6 +3053,21 @@ template<> PROTOBUF_NOINLINE ::embedding::EmbeddingBatchItem* Arena::CreateMaybe
 }
 template<> PROTOBUF_NOINLINE ::embedding::EmbeddingBatchResponse* Arena::CreateMaybeMessage< ::embedding::EmbeddingBatchResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::embedding::EmbeddingBatchResponse >(arena);
+}
+template<> PROTOBUF_NOINLINE ::embedding::RerankQuery* Arena::CreateMaybeMessage< ::embedding::RerankQuery >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::embedding::RerankQuery >(arena);
+}
+template<> PROTOBUF_NOINLINE ::embedding::RerankRequest* Arena::CreateMaybeMessage< ::embedding::RerankRequest >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::embedding::RerankRequest >(arena);
+}
+template<> PROTOBUF_NOINLINE ::embedding::RerankItem* Arena::CreateMaybeMessage< ::embedding::RerankItem >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::embedding::RerankItem >(arena);
+}
+template<> PROTOBUF_NOINLINE ::embedding::RerankResult* Arena::CreateMaybeMessage< ::embedding::RerankResult >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::embedding::RerankResult >(arena);
+}
+template<> PROTOBUF_NOINLINE ::embedding::RerankResponse* Arena::CreateMaybeMessage< ::embedding::RerankResponse >(Arena* arena) {
+  return Arena::CreateMessageInternal< ::embedding::RerankResponse >(arena);
 }
 template<> PROTOBUF_NOINLINE ::embedding::InfoResponse* Arena::CreateMaybeMessage< ::embedding::InfoResponse >(Arena* arena) {
   return Arena::CreateMessageInternal< ::embedding::InfoResponse >(arena);

--- a/local_embedding_service/generated/embedding.pb.h
+++ b/local_embedding_service/generated/embedding.pb.h
@@ -48,7 +48,7 @@ struct TableStruct_embedding_2eproto {
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::AuxillaryParseTableField aux[]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
-  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[6]
+  static const ::PROTOBUF_NAMESPACE_ID::internal::ParseTable schema[11]
     PROTOBUF_SECTION_VARIABLE(protodesc_cold);
   static const ::PROTOBUF_NAMESPACE_ID::internal::FieldMetadata field_metadata[];
   static const ::PROTOBUF_NAMESPACE_ID::internal::SerializationTable serialization_table[];
@@ -74,6 +74,21 @@ extern EmbeddingResponseDefaultTypeInternal _EmbeddingResponse_default_instance_
 class InfoResponse;
 class InfoResponseDefaultTypeInternal;
 extern InfoResponseDefaultTypeInternal _InfoResponse_default_instance_;
+class RerankItem;
+class RerankItemDefaultTypeInternal;
+extern RerankItemDefaultTypeInternal _RerankItem_default_instance_;
+class RerankQuery;
+class RerankQueryDefaultTypeInternal;
+extern RerankQueryDefaultTypeInternal _RerankQuery_default_instance_;
+class RerankRequest;
+class RerankRequestDefaultTypeInternal;
+extern RerankRequestDefaultTypeInternal _RerankRequest_default_instance_;
+class RerankResponse;
+class RerankResponseDefaultTypeInternal;
+extern RerankResponseDefaultTypeInternal _RerankResponse_default_instance_;
+class RerankResult;
+class RerankResultDefaultTypeInternal;
+extern RerankResultDefaultTypeInternal _RerankResult_default_instance_;
 }  // namespace embedding
 PROTOBUF_NAMESPACE_OPEN
 template<> ::embedding::EmbeddingBatchItem* Arena::CreateMaybeMessage<::embedding::EmbeddingBatchItem>(Arena*);
@@ -82,6 +97,11 @@ template<> ::embedding::EmbeddingBatchResponse* Arena::CreateMaybeMessage<::embe
 template<> ::embedding::EmbeddingRequest* Arena::CreateMaybeMessage<::embedding::EmbeddingRequest>(Arena*);
 template<> ::embedding::EmbeddingResponse* Arena::CreateMaybeMessage<::embedding::EmbeddingResponse>(Arena*);
 template<> ::embedding::InfoResponse* Arena::CreateMaybeMessage<::embedding::InfoResponse>(Arena*);
+template<> ::embedding::RerankItem* Arena::CreateMaybeMessage<::embedding::RerankItem>(Arena*);
+template<> ::embedding::RerankQuery* Arena::CreateMaybeMessage<::embedding::RerankQuery>(Arena*);
+template<> ::embedding::RerankRequest* Arena::CreateMaybeMessage<::embedding::RerankRequest>(Arena*);
+template<> ::embedding::RerankResponse* Arena::CreateMaybeMessage<::embedding::RerankResponse>(Arena*);
+template<> ::embedding::RerankResult* Arena::CreateMaybeMessage<::embedding::RerankResult>(Arena*);
 PROTOBUF_NAMESPACE_CLOSE
 namespace embedding {
 
@@ -921,6 +941,863 @@ class EmbeddingBatchResponse PROTOBUF_FINAL :
 };
 // -------------------------------------------------------------------
 
+class RerankQuery PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.RerankQuery) */ {
+ public:
+  inline RerankQuery() : RerankQuery(nullptr) {};
+  virtual ~RerankQuery();
+
+  RerankQuery(const RerankQuery& from);
+  RerankQuery(RerankQuery&& from) noexcept
+    : RerankQuery() {
+    *this = ::std::move(from);
+  }
+
+  inline RerankQuery& operator=(const RerankQuery& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RerankQuery& operator=(RerankQuery&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const RerankQuery& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RerankQuery* internal_default_instance() {
+    return reinterpret_cast<const RerankQuery*>(
+               &_RerankQuery_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    5;
+
+  friend void swap(RerankQuery& a, RerankQuery& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RerankQuery* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RerankQuery* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RerankQuery* New() const final {
+    return CreateMaybeMessage<RerankQuery>(nullptr);
+  }
+
+  RerankQuery* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<RerankQuery>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const RerankQuery& from);
+  void MergeFrom(const RerankQuery& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RerankQuery* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "embedding.RerankQuery";
+  }
+  protected:
+  explicit RerankQuery(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_embedding_2eproto);
+    return ::descriptor_table_embedding_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDocumentsFieldNumber = 2,
+    kQueryFieldNumber = 1,
+    kTopKFieldNumber = 3,
+  };
+  // repeated string documents = 2;
+  int documents_size() const;
+  private:
+  int _internal_documents_size() const;
+  public:
+  void clear_documents();
+  const std::string& documents(int index) const;
+  std::string* mutable_documents(int index);
+  void set_documents(int index, const std::string& value);
+  void set_documents(int index, std::string&& value);
+  void set_documents(int index, const char* value);
+  void set_documents(int index, const char* value, size_t size);
+  std::string* add_documents();
+  void add_documents(const std::string& value);
+  void add_documents(std::string&& value);
+  void add_documents(const char* value);
+  void add_documents(const char* value, size_t size);
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>& documents() const;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>* mutable_documents();
+  private:
+  const std::string& _internal_documents(int index) const;
+  std::string* _internal_add_documents();
+  public:
+
+  // string query = 1;
+  void clear_query();
+  const std::string& query() const;
+  void set_query(const std::string& value);
+  void set_query(std::string&& value);
+  void set_query(const char* value);
+  void set_query(const char* value, size_t size);
+  std::string* mutable_query();
+  std::string* release_query();
+  void set_allocated_query(std::string* query);
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  std::string* unsafe_arena_release_query();
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  void unsafe_arena_set_allocated_query(
+      std::string* query);
+  private:
+  const std::string& _internal_query() const;
+  void _internal_set_query(const std::string& value);
+  std::string* _internal_mutable_query();
+  public:
+
+  // int32 top_k = 3;
+  void clear_top_k();
+  ::PROTOBUF_NAMESPACE_ID::int32 top_k() const;
+  void set_top_k(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_top_k() const;
+  void _internal_set_top_k(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:embedding.RerankQuery)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string> documents_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr query_;
+  ::PROTOBUF_NAMESPACE_ID::int32 top_k_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_embedding_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RerankRequest PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.RerankRequest) */ {
+ public:
+  inline RerankRequest() : RerankRequest(nullptr) {};
+  virtual ~RerankRequest();
+
+  RerankRequest(const RerankRequest& from);
+  RerankRequest(RerankRequest&& from) noexcept
+    : RerankRequest() {
+    *this = ::std::move(from);
+  }
+
+  inline RerankRequest& operator=(const RerankRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RerankRequest& operator=(RerankRequest&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const RerankRequest& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RerankRequest* internal_default_instance() {
+    return reinterpret_cast<const RerankRequest*>(
+               &_RerankRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    6;
+
+  friend void swap(RerankRequest& a, RerankRequest& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RerankRequest* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RerankRequest* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RerankRequest* New() const final {
+    return CreateMaybeMessage<RerankRequest>(nullptr);
+  }
+
+  RerankRequest* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<RerankRequest>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const RerankRequest& from);
+  void MergeFrom(const RerankRequest& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RerankRequest* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "embedding.RerankRequest";
+  }
+  protected:
+  explicit RerankRequest(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_embedding_2eproto);
+    return ::descriptor_table_embedding_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kQueriesFieldNumber = 1,
+  };
+  // repeated .embedding.RerankQuery queries = 1;
+  int queries_size() const;
+  private:
+  int _internal_queries_size() const;
+  public:
+  void clear_queries();
+  ::embedding::RerankQuery* mutable_queries(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankQuery >*
+      mutable_queries();
+  private:
+  const ::embedding::RerankQuery& _internal_queries(int index) const;
+  ::embedding::RerankQuery* _internal_add_queries();
+  public:
+  const ::embedding::RerankQuery& queries(int index) const;
+  ::embedding::RerankQuery* add_queries();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankQuery >&
+      queries() const;
+
+  // @@protoc_insertion_point(class_scope:embedding.RerankRequest)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankQuery > queries_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_embedding_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RerankItem PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.RerankItem) */ {
+ public:
+  inline RerankItem() : RerankItem(nullptr) {};
+  virtual ~RerankItem();
+
+  RerankItem(const RerankItem& from);
+  RerankItem(RerankItem&& from) noexcept
+    : RerankItem() {
+    *this = ::std::move(from);
+  }
+
+  inline RerankItem& operator=(const RerankItem& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RerankItem& operator=(RerankItem&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const RerankItem& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RerankItem* internal_default_instance() {
+    return reinterpret_cast<const RerankItem*>(
+               &_RerankItem_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    7;
+
+  friend void swap(RerankItem& a, RerankItem& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RerankItem* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RerankItem* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RerankItem* New() const final {
+    return CreateMaybeMessage<RerankItem>(nullptr);
+  }
+
+  RerankItem* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<RerankItem>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const RerankItem& from);
+  void MergeFrom(const RerankItem& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RerankItem* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "embedding.RerankItem";
+  }
+  protected:
+  explicit RerankItem(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_embedding_2eproto);
+    return ::descriptor_table_embedding_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kDocumentFieldNumber = 2,
+    kIndexFieldNumber = 1,
+    kScoreFieldNumber = 3,
+  };
+  // string document = 2;
+  void clear_document();
+  const std::string& document() const;
+  void set_document(const std::string& value);
+  void set_document(std::string&& value);
+  void set_document(const char* value);
+  void set_document(const char* value, size_t size);
+  std::string* mutable_document();
+  std::string* release_document();
+  void set_allocated_document(std::string* document);
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  std::string* unsafe_arena_release_document();
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  void unsafe_arena_set_allocated_document(
+      std::string* document);
+  private:
+  const std::string& _internal_document() const;
+  void _internal_set_document(const std::string& value);
+  std::string* _internal_mutable_document();
+  public:
+
+  // int32 index = 1;
+  void clear_index();
+  ::PROTOBUF_NAMESPACE_ID::int32 index() const;
+  void set_index(::PROTOBUF_NAMESPACE_ID::int32 value);
+  private:
+  ::PROTOBUF_NAMESPACE_ID::int32 _internal_index() const;
+  void _internal_set_index(::PROTOBUF_NAMESPACE_ID::int32 value);
+  public:
+
+  // float score = 3;
+  void clear_score();
+  float score() const;
+  void set_score(float value);
+  private:
+  float _internal_score() const;
+  void _internal_set_score(float value);
+  public:
+
+  // @@protoc_insertion_point(class_scope:embedding.RerankItem)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr document_;
+  ::PROTOBUF_NAMESPACE_ID::int32 index_;
+  float score_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_embedding_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RerankResult PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.RerankResult) */ {
+ public:
+  inline RerankResult() : RerankResult(nullptr) {};
+  virtual ~RerankResult();
+
+  RerankResult(const RerankResult& from);
+  RerankResult(RerankResult&& from) noexcept
+    : RerankResult() {
+    *this = ::std::move(from);
+  }
+
+  inline RerankResult& operator=(const RerankResult& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RerankResult& operator=(RerankResult&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const RerankResult& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RerankResult* internal_default_instance() {
+    return reinterpret_cast<const RerankResult*>(
+               &_RerankResult_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  friend void swap(RerankResult& a, RerankResult& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RerankResult* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RerankResult* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RerankResult* New() const final {
+    return CreateMaybeMessage<RerankResult>(nullptr);
+  }
+
+  RerankResult* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<RerankResult>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const RerankResult& from);
+  void MergeFrom(const RerankResult& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RerankResult* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "embedding.RerankResult";
+  }
+  protected:
+  explicit RerankResult(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_embedding_2eproto);
+    return ::descriptor_table_embedding_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kItemsFieldNumber = 1,
+    kErrorFieldNumber = 2,
+  };
+  // repeated .embedding.RerankItem items = 1;
+  int items_size() const;
+  private:
+  int _internal_items_size() const;
+  public:
+  void clear_items();
+  ::embedding::RerankItem* mutable_items(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankItem >*
+      mutable_items();
+  private:
+  const ::embedding::RerankItem& _internal_items(int index) const;
+  ::embedding::RerankItem* _internal_add_items();
+  public:
+  const ::embedding::RerankItem& items(int index) const;
+  ::embedding::RerankItem* add_items();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankItem >&
+      items() const;
+
+  // string error = 2;
+  void clear_error();
+  const std::string& error() const;
+  void set_error(const std::string& value);
+  void set_error(std::string&& value);
+  void set_error(const char* value);
+  void set_error(const char* value, size_t size);
+  std::string* mutable_error();
+  std::string* release_error();
+  void set_allocated_error(std::string* error);
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  std::string* unsafe_arena_release_error();
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  void unsafe_arena_set_allocated_error(
+      std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // @@protoc_insertion_point(class_scope:embedding.RerankResult)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankItem > items_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_embedding_2eproto;
+};
+// -------------------------------------------------------------------
+
+class RerankResponse PROTOBUF_FINAL :
+    public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.RerankResponse) */ {
+ public:
+  inline RerankResponse() : RerankResponse(nullptr) {};
+  virtual ~RerankResponse();
+
+  RerankResponse(const RerankResponse& from);
+  RerankResponse(RerankResponse&& from) noexcept
+    : RerankResponse() {
+    *this = ::std::move(from);
+  }
+
+  inline RerankResponse& operator=(const RerankResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline RerankResponse& operator=(RerankResponse&& from) noexcept {
+    if (GetArena() == from.GetArena()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Descriptor* GetDescriptor() {
+    return GetMetadataStatic().descriptor;
+  }
+  static const ::PROTOBUF_NAMESPACE_ID::Reflection* GetReflection() {
+    return GetMetadataStatic().reflection;
+  }
+  static const RerankResponse& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const RerankResponse* internal_default_instance() {
+    return reinterpret_cast<const RerankResponse*>(
+               &_RerankResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    9;
+
+  friend void swap(RerankResponse& a, RerankResponse& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(RerankResponse* other) {
+    if (other == this) return;
+    if (GetArena() == other->GetArena()) {
+      InternalSwap(other);
+    } else {
+      ::PROTOBUF_NAMESPACE_ID::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(RerankResponse* other) {
+    if (other == this) return;
+    GOOGLE_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline RerankResponse* New() const final {
+    return CreateMaybeMessage<RerankResponse>(nullptr);
+  }
+
+  RerankResponse* New(::PROTOBUF_NAMESPACE_ID::Arena* arena) const final {
+    return CreateMaybeMessage<RerankResponse>(arena);
+  }
+  void CopyFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void MergeFrom(const ::PROTOBUF_NAMESPACE_ID::Message& from) final;
+  void CopyFrom(const RerankResponse& from);
+  void MergeFrom(const RerankResponse& from);
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::PROTOBUF_NAMESPACE_ID::internal::ParseContext* ctx) final;
+  ::PROTOBUF_NAMESPACE_ID::uint8* _InternalSerialize(
+      ::PROTOBUF_NAMESPACE_ID::uint8* target, ::PROTOBUF_NAMESPACE_ID::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  inline void SharedCtor();
+  inline void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(RerankResponse* other);
+  friend class ::PROTOBUF_NAMESPACE_ID::internal::AnyMetadata;
+  static ::PROTOBUF_NAMESPACE_ID::StringPiece FullMessageName() {
+    return "embedding.RerankResponse";
+  }
+  protected:
+  explicit RerankResponse(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  private:
+  static void ArenaDtor(void* object);
+  inline void RegisterArenaDtor(::PROTOBUF_NAMESPACE_ID::Arena* arena);
+  public:
+
+  ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadata() const final;
+  private:
+  static ::PROTOBUF_NAMESPACE_ID::Metadata GetMetadataStatic() {
+    ::PROTOBUF_NAMESPACE_ID::internal::AssignDescriptors(&::descriptor_table_embedding_2eproto);
+    return ::descriptor_table_embedding_2eproto.file_level_metadata[kIndexInFileMessages];
+  }
+
+  public:
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kResultsFieldNumber = 1,
+    kErrorFieldNumber = 2,
+  };
+  // repeated .embedding.RerankResult results = 1;
+  int results_size() const;
+  private:
+  int _internal_results_size() const;
+  public:
+  void clear_results();
+  ::embedding::RerankResult* mutable_results(int index);
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankResult >*
+      mutable_results();
+  private:
+  const ::embedding::RerankResult& _internal_results(int index) const;
+  ::embedding::RerankResult* _internal_add_results();
+  public:
+  const ::embedding::RerankResult& results(int index) const;
+  ::embedding::RerankResult* add_results();
+  const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankResult >&
+      results() const;
+
+  // string error = 2;
+  void clear_error();
+  const std::string& error() const;
+  void set_error(const std::string& value);
+  void set_error(std::string&& value);
+  void set_error(const char* value);
+  void set_error(const char* value, size_t size);
+  std::string* mutable_error();
+  std::string* release_error();
+  void set_allocated_error(std::string* error);
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  std::string* unsafe_arena_release_error();
+  GOOGLE_PROTOBUF_RUNTIME_DEPRECATED("The unsafe_arena_ accessors for"
+  "    string fields are deprecated and will be removed in a"
+  "    future release.")
+  void unsafe_arena_set_allocated_error(
+      std::string* error);
+  private:
+  const std::string& _internal_error() const;
+  void _internal_set_error(const std::string& value);
+  std::string* _internal_mutable_error();
+  public:
+
+  // @@protoc_insertion_point(class_scope:embedding.RerankResponse)
+ private:
+  class _Internal;
+
+  template <typename T> friend class ::PROTOBUF_NAMESPACE_ID::Arena::InternalHelper;
+  typedef void InternalArenaConstructable_;
+  typedef void DestructorSkippable_;
+  ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankResult > results_;
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr error_;
+  mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
+  friend struct ::TableStruct_embedding_2eproto;
+};
+// -------------------------------------------------------------------
+
 class InfoResponse PROTOBUF_FINAL :
     public ::PROTOBUF_NAMESPACE_ID::Message /* @@protoc_insertion_point(class_definition:embedding.InfoResponse) */ {
  public:
@@ -963,7 +1840,7 @@ class InfoResponse PROTOBUF_FINAL :
                &_InfoResponse_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    10;
 
   friend void swap(InfoResponse& a, InfoResponse& b) {
     a.Swap(&b);
@@ -1670,6 +2547,601 @@ inline void EmbeddingBatchResponse::unsafe_arena_set_allocated_error(
 
 // -------------------------------------------------------------------
 
+// RerankQuery
+
+// string query = 1;
+inline void RerankQuery::clear_query() {
+  query_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline const std::string& RerankQuery::query() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankQuery.query)
+  return _internal_query();
+}
+inline void RerankQuery::set_query(const std::string& value) {
+  _internal_set_query(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankQuery.query)
+}
+inline std::string* RerankQuery::mutable_query() {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankQuery.query)
+  return _internal_mutable_query();
+}
+inline const std::string& RerankQuery::_internal_query() const {
+  return query_.Get();
+}
+inline void RerankQuery::_internal_set_query(const std::string& value) {
+  
+  query_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value, GetArena());
+}
+inline void RerankQuery::set_query(std::string&& value) {
+  
+  query_.Set(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:embedding.RerankQuery.query)
+}
+inline void RerankQuery::set_query(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  query_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
+              GetArena());
+  // @@protoc_insertion_point(field_set_char:embedding.RerankQuery.query)
+}
+inline void RerankQuery::set_query(const char* value,
+    size_t size) {
+  
+  query_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:embedding.RerankQuery.query)
+}
+inline std::string* RerankQuery::_internal_mutable_query() {
+  
+  return query_.Mutable(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline std::string* RerankQuery::release_query() {
+  // @@protoc_insertion_point(field_release:embedding.RerankQuery.query)
+  return query_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void RerankQuery::set_allocated_query(std::string* query) {
+  if (query != nullptr) {
+    
+  } else {
+    
+  }
+  query_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), query,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:embedding.RerankQuery.query)
+}
+inline std::string* RerankQuery::unsafe_arena_release_query() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:embedding.RerankQuery.query)
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  
+  return query_.UnsafeArenaRelease(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      GetArena());
+}
+inline void RerankQuery::unsafe_arena_set_allocated_query(
+    std::string* query) {
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  if (query != nullptr) {
+    
+  } else {
+    
+  }
+  query_.UnsafeArenaSetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      query, GetArena());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:embedding.RerankQuery.query)
+}
+
+// repeated string documents = 2;
+inline int RerankQuery::_internal_documents_size() const {
+  return documents_.size();
+}
+inline int RerankQuery::documents_size() const {
+  return _internal_documents_size();
+}
+inline void RerankQuery::clear_documents() {
+  documents_.Clear();
+}
+inline std::string* RerankQuery::add_documents() {
+  // @@protoc_insertion_point(field_add_mutable:embedding.RerankQuery.documents)
+  return _internal_add_documents();
+}
+inline const std::string& RerankQuery::_internal_documents(int index) const {
+  return documents_.Get(index);
+}
+inline const std::string& RerankQuery::documents(int index) const {
+  // @@protoc_insertion_point(field_get:embedding.RerankQuery.documents)
+  return _internal_documents(index);
+}
+inline std::string* RerankQuery::mutable_documents(int index) {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankQuery.documents)
+  return documents_.Mutable(index);
+}
+inline void RerankQuery::set_documents(int index, const std::string& value) {
+  // @@protoc_insertion_point(field_set:embedding.RerankQuery.documents)
+  documents_.Mutable(index)->assign(value);
+}
+inline void RerankQuery::set_documents(int index, std::string&& value) {
+  // @@protoc_insertion_point(field_set:embedding.RerankQuery.documents)
+  documents_.Mutable(index)->assign(std::move(value));
+}
+inline void RerankQuery::set_documents(int index, const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  documents_.Mutable(index)->assign(value);
+  // @@protoc_insertion_point(field_set_char:embedding.RerankQuery.documents)
+}
+inline void RerankQuery::set_documents(int index, const char* value, size_t size) {
+  documents_.Mutable(index)->assign(
+    reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_set_pointer:embedding.RerankQuery.documents)
+}
+inline std::string* RerankQuery::_internal_add_documents() {
+  return documents_.Add();
+}
+inline void RerankQuery::add_documents(const std::string& value) {
+  documents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add:embedding.RerankQuery.documents)
+}
+inline void RerankQuery::add_documents(std::string&& value) {
+  documents_.Add(std::move(value));
+  // @@protoc_insertion_point(field_add:embedding.RerankQuery.documents)
+}
+inline void RerankQuery::add_documents(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  documents_.Add()->assign(value);
+  // @@protoc_insertion_point(field_add_char:embedding.RerankQuery.documents)
+}
+inline void RerankQuery::add_documents(const char* value, size_t size) {
+  documents_.Add()->assign(reinterpret_cast<const char*>(value), size);
+  // @@protoc_insertion_point(field_add_pointer:embedding.RerankQuery.documents)
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>&
+RerankQuery::documents() const {
+  // @@protoc_insertion_point(field_list:embedding.RerankQuery.documents)
+  return documents_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField<std::string>*
+RerankQuery::mutable_documents() {
+  // @@protoc_insertion_point(field_mutable_list:embedding.RerankQuery.documents)
+  return &documents_;
+}
+
+// int32 top_k = 3;
+inline void RerankQuery::clear_top_k() {
+  top_k_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 RerankQuery::_internal_top_k() const {
+  return top_k_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 RerankQuery::top_k() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankQuery.top_k)
+  return _internal_top_k();
+}
+inline void RerankQuery::_internal_set_top_k(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  top_k_ = value;
+}
+inline void RerankQuery::set_top_k(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_top_k(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankQuery.top_k)
+}
+
+// -------------------------------------------------------------------
+
+// RerankRequest
+
+// repeated .embedding.RerankQuery queries = 1;
+inline int RerankRequest::_internal_queries_size() const {
+  return queries_.size();
+}
+inline int RerankRequest::queries_size() const {
+  return _internal_queries_size();
+}
+inline void RerankRequest::clear_queries() {
+  queries_.Clear();
+}
+inline ::embedding::RerankQuery* RerankRequest::mutable_queries(int index) {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankRequest.queries)
+  return queries_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankQuery >*
+RerankRequest::mutable_queries() {
+  // @@protoc_insertion_point(field_mutable_list:embedding.RerankRequest.queries)
+  return &queries_;
+}
+inline const ::embedding::RerankQuery& RerankRequest::_internal_queries(int index) const {
+  return queries_.Get(index);
+}
+inline const ::embedding::RerankQuery& RerankRequest::queries(int index) const {
+  // @@protoc_insertion_point(field_get:embedding.RerankRequest.queries)
+  return _internal_queries(index);
+}
+inline ::embedding::RerankQuery* RerankRequest::_internal_add_queries() {
+  return queries_.Add();
+}
+inline ::embedding::RerankQuery* RerankRequest::add_queries() {
+  // @@protoc_insertion_point(field_add:embedding.RerankRequest.queries)
+  return _internal_add_queries();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankQuery >&
+RerankRequest::queries() const {
+  // @@protoc_insertion_point(field_list:embedding.RerankRequest.queries)
+  return queries_;
+}
+
+// -------------------------------------------------------------------
+
+// RerankItem
+
+// int32 index = 1;
+inline void RerankItem::clear_index() {
+  index_ = 0;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 RerankItem::_internal_index() const {
+  return index_;
+}
+inline ::PROTOBUF_NAMESPACE_ID::int32 RerankItem::index() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankItem.index)
+  return _internal_index();
+}
+inline void RerankItem::_internal_set_index(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  
+  index_ = value;
+}
+inline void RerankItem::set_index(::PROTOBUF_NAMESPACE_ID::int32 value) {
+  _internal_set_index(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankItem.index)
+}
+
+// string document = 2;
+inline void RerankItem::clear_document() {
+  document_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline const std::string& RerankItem::document() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankItem.document)
+  return _internal_document();
+}
+inline void RerankItem::set_document(const std::string& value) {
+  _internal_set_document(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankItem.document)
+}
+inline std::string* RerankItem::mutable_document() {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankItem.document)
+  return _internal_mutable_document();
+}
+inline const std::string& RerankItem::_internal_document() const {
+  return document_.Get();
+}
+inline void RerankItem::_internal_set_document(const std::string& value) {
+  
+  document_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value, GetArena());
+}
+inline void RerankItem::set_document(std::string&& value) {
+  
+  document_.Set(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:embedding.RerankItem.document)
+}
+inline void RerankItem::set_document(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  document_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
+              GetArena());
+  // @@protoc_insertion_point(field_set_char:embedding.RerankItem.document)
+}
+inline void RerankItem::set_document(const char* value,
+    size_t size) {
+  
+  document_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:embedding.RerankItem.document)
+}
+inline std::string* RerankItem::_internal_mutable_document() {
+  
+  return document_.Mutable(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline std::string* RerankItem::release_document() {
+  // @@protoc_insertion_point(field_release:embedding.RerankItem.document)
+  return document_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void RerankItem::set_allocated_document(std::string* document) {
+  if (document != nullptr) {
+    
+  } else {
+    
+  }
+  document_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), document,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:embedding.RerankItem.document)
+}
+inline std::string* RerankItem::unsafe_arena_release_document() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:embedding.RerankItem.document)
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  
+  return document_.UnsafeArenaRelease(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      GetArena());
+}
+inline void RerankItem::unsafe_arena_set_allocated_document(
+    std::string* document) {
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  if (document != nullptr) {
+    
+  } else {
+    
+  }
+  document_.UnsafeArenaSetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      document, GetArena());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:embedding.RerankItem.document)
+}
+
+// float score = 3;
+inline void RerankItem::clear_score() {
+  score_ = 0;
+}
+inline float RerankItem::_internal_score() const {
+  return score_;
+}
+inline float RerankItem::score() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankItem.score)
+  return _internal_score();
+}
+inline void RerankItem::_internal_set_score(float value) {
+  
+  score_ = value;
+}
+inline void RerankItem::set_score(float value) {
+  _internal_set_score(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankItem.score)
+}
+
+// -------------------------------------------------------------------
+
+// RerankResult
+
+// repeated .embedding.RerankItem items = 1;
+inline int RerankResult::_internal_items_size() const {
+  return items_.size();
+}
+inline int RerankResult::items_size() const {
+  return _internal_items_size();
+}
+inline void RerankResult::clear_items() {
+  items_.Clear();
+}
+inline ::embedding::RerankItem* RerankResult::mutable_items(int index) {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankResult.items)
+  return items_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankItem >*
+RerankResult::mutable_items() {
+  // @@protoc_insertion_point(field_mutable_list:embedding.RerankResult.items)
+  return &items_;
+}
+inline const ::embedding::RerankItem& RerankResult::_internal_items(int index) const {
+  return items_.Get(index);
+}
+inline const ::embedding::RerankItem& RerankResult::items(int index) const {
+  // @@protoc_insertion_point(field_get:embedding.RerankResult.items)
+  return _internal_items(index);
+}
+inline ::embedding::RerankItem* RerankResult::_internal_add_items() {
+  return items_.Add();
+}
+inline ::embedding::RerankItem* RerankResult::add_items() {
+  // @@protoc_insertion_point(field_add:embedding.RerankResult.items)
+  return _internal_add_items();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankItem >&
+RerankResult::items() const {
+  // @@protoc_insertion_point(field_list:embedding.RerankResult.items)
+  return items_;
+}
+
+// string error = 2;
+inline void RerankResult::clear_error() {
+  error_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline const std::string& RerankResult::error() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankResult.error)
+  return _internal_error();
+}
+inline void RerankResult::set_error(const std::string& value) {
+  _internal_set_error(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankResult.error)
+}
+inline std::string* RerankResult::mutable_error() {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankResult.error)
+  return _internal_mutable_error();
+}
+inline const std::string& RerankResult::_internal_error() const {
+  return error_.Get();
+}
+inline void RerankResult::_internal_set_error(const std::string& value) {
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value, GetArena());
+}
+inline void RerankResult::set_error(std::string&& value) {
+  
+  error_.Set(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:embedding.RerankResult.error)
+}
+inline void RerankResult::set_error(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
+              GetArena());
+  // @@protoc_insertion_point(field_set_char:embedding.RerankResult.error)
+}
+inline void RerankResult::set_error(const char* value,
+    size_t size) {
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:embedding.RerankResult.error)
+}
+inline std::string* RerankResult::_internal_mutable_error() {
+  
+  return error_.Mutable(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline std::string* RerankResult::release_error() {
+  // @@protoc_insertion_point(field_release:embedding.RerankResult.error)
+  return error_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void RerankResult::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    
+  } else {
+    
+  }
+  error_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), error,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:embedding.RerankResult.error)
+}
+inline std::string* RerankResult::unsafe_arena_release_error() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:embedding.RerankResult.error)
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  
+  return error_.UnsafeArenaRelease(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      GetArena());
+}
+inline void RerankResult::unsafe_arena_set_allocated_error(
+    std::string* error) {
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  if (error != nullptr) {
+    
+  } else {
+    
+  }
+  error_.UnsafeArenaSetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      error, GetArena());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:embedding.RerankResult.error)
+}
+
+// -------------------------------------------------------------------
+
+// RerankResponse
+
+// repeated .embedding.RerankResult results = 1;
+inline int RerankResponse::_internal_results_size() const {
+  return results_.size();
+}
+inline int RerankResponse::results_size() const {
+  return _internal_results_size();
+}
+inline void RerankResponse::clear_results() {
+  results_.Clear();
+}
+inline ::embedding::RerankResult* RerankResponse::mutable_results(int index) {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankResponse.results)
+  return results_.Mutable(index);
+}
+inline ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankResult >*
+RerankResponse::mutable_results() {
+  // @@protoc_insertion_point(field_mutable_list:embedding.RerankResponse.results)
+  return &results_;
+}
+inline const ::embedding::RerankResult& RerankResponse::_internal_results(int index) const {
+  return results_.Get(index);
+}
+inline const ::embedding::RerankResult& RerankResponse::results(int index) const {
+  // @@protoc_insertion_point(field_get:embedding.RerankResponse.results)
+  return _internal_results(index);
+}
+inline ::embedding::RerankResult* RerankResponse::_internal_add_results() {
+  return results_.Add();
+}
+inline ::embedding::RerankResult* RerankResponse::add_results() {
+  // @@protoc_insertion_point(field_add:embedding.RerankResponse.results)
+  return _internal_add_results();
+}
+inline const ::PROTOBUF_NAMESPACE_ID::RepeatedPtrField< ::embedding::RerankResult >&
+RerankResponse::results() const {
+  // @@protoc_insertion_point(field_list:embedding.RerankResponse.results)
+  return results_;
+}
+
+// string error = 2;
+inline void RerankResponse::clear_error() {
+  error_.ClearToEmpty(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline const std::string& RerankResponse::error() const {
+  // @@protoc_insertion_point(field_get:embedding.RerankResponse.error)
+  return _internal_error();
+}
+inline void RerankResponse::set_error(const std::string& value) {
+  _internal_set_error(value);
+  // @@protoc_insertion_point(field_set:embedding.RerankResponse.error)
+}
+inline std::string* RerankResponse::mutable_error() {
+  // @@protoc_insertion_point(field_mutable:embedding.RerankResponse.error)
+  return _internal_mutable_error();
+}
+inline const std::string& RerankResponse::_internal_error() const {
+  return error_.Get();
+}
+inline void RerankResponse::_internal_set_error(const std::string& value) {
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), value, GetArena());
+}
+inline void RerankResponse::set_error(std::string&& value) {
+  
+  error_.Set(
+    &::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::move(value), GetArena());
+  // @@protoc_insertion_point(field_set_rvalue:embedding.RerankResponse.error)
+}
+inline void RerankResponse::set_error(const char* value) {
+  GOOGLE_DCHECK(value != nullptr);
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(value),
+              GetArena());
+  // @@protoc_insertion_point(field_set_char:embedding.RerankResponse.error)
+}
+inline void RerankResponse::set_error(const char* value,
+    size_t size) {
+  
+  error_.Set(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), ::std::string(
+      reinterpret_cast<const char*>(value), size), GetArena());
+  // @@protoc_insertion_point(field_set_pointer:embedding.RerankResponse.error)
+}
+inline std::string* RerankResponse::_internal_mutable_error() {
+  
+  return error_.Mutable(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline std::string* RerankResponse::release_error() {
+  // @@protoc_insertion_point(field_release:embedding.RerankResponse.error)
+  return error_.Release(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), GetArena());
+}
+inline void RerankResponse::set_allocated_error(std::string* error) {
+  if (error != nullptr) {
+    
+  } else {
+    
+  }
+  error_.SetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(), error,
+      GetArena());
+  // @@protoc_insertion_point(field_set_allocated:embedding.RerankResponse.error)
+}
+inline std::string* RerankResponse::unsafe_arena_release_error() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:embedding.RerankResponse.error)
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  
+  return error_.UnsafeArenaRelease(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      GetArena());
+}
+inline void RerankResponse::unsafe_arena_set_allocated_error(
+    std::string* error) {
+  GOOGLE_DCHECK(GetArena() != nullptr);
+  if (error != nullptr) {
+    
+  } else {
+    
+  }
+  error_.UnsafeArenaSetAllocated(&::PROTOBUF_NAMESPACE_ID::internal::GetEmptyStringAlreadyInited(),
+      error, GetArena());
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:embedding.RerankResponse.error)
+}
+
+// -------------------------------------------------------------------
+
 // InfoResponse
 
 // string provider = 1;
@@ -1857,6 +3329,16 @@ inline void InfoResponse::set_dimensions(::PROTOBUF_NAMESPACE_ID::int32 value) {
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------

--- a/local_embedding_service/include/embedding_service_impl.h
+++ b/local_embedding_service/include/embedding_service_impl.h
@@ -22,6 +22,9 @@ class EmbeddingServiceImpl final : public embedding::EmbeddingService::Service {
   grpc::Status GetEmbeddings(grpc::ServerContext* context,
                              const embedding::EmbeddingBatchRequest* request,
                              embedding::EmbeddingBatchResponse* response) override;
+  grpc::Status Rerank(grpc::ServerContext* context,
+                      const embedding::RerankRequest* request,
+                      embedding::RerankResponse* response) override;
 
   grpc::Status Info(grpc::ServerContext* context,
                     const google::protobuf::Empty* request,

--- a/local_embedding_service/proto/embedding.proto
+++ b/local_embedding_service/proto/embedding.proto
@@ -9,6 +9,7 @@ import "google/protobuf/empty.proto";
 service EmbeddingService {
   rpc GetEmbedding(EmbeddingRequest) returns (EmbeddingResponse);
   rpc GetEmbeddings(EmbeddingBatchRequest) returns (EmbeddingBatchResponse);
+  rpc Rerank(RerankRequest) returns (RerankResponse);
   rpc Info(google.protobuf.Empty) returns (InfoResponse);
 }
 
@@ -32,6 +33,32 @@ message EmbeddingBatchItem {
 
 message EmbeddingBatchResponse {
   repeated EmbeddingBatchItem items = 1;
+  string error = 2;
+}
+
+message RerankQuery {
+  string query = 1;
+  repeated string documents = 2;
+  int32 top_k = 3;
+}
+
+message RerankRequest {
+  repeated RerankQuery queries = 1;
+}
+
+message RerankItem {
+  int32 index = 1;
+  string document = 2;
+  float score = 3;
+}
+
+message RerankResult {
+  repeated RerankItem items = 1;
+  string error = 2;
+}
+
+message RerankResponse {
+  repeated RerankResult results = 1;
   string error = 2;
 }
 

--- a/local_embedding_service/src/embedding_service_impl.cpp
+++ b/local_embedding_service/src/embedding_service_impl.cpp
@@ -1,7 +1,13 @@
 #include "embedding_service_impl.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "mock_embedding_backend.h"
 
@@ -10,6 +16,33 @@
 #endif
 
 namespace embedding_service {
+
+namespace {
+
+std::vector<std::string> TokenizeForRerank(const std::string& text) {
+  std::vector<std::string> tokens;
+  std::string current;
+  current.reserve(text.size());
+  for (unsigned char ch : text) {
+    if (std::isalnum(ch)) {
+      current.push_back(static_cast<char>(std::tolower(ch)));
+    } else if (!current.empty()) {
+      tokens.push_back(current);
+      current.clear();
+    }
+  }
+  if (!current.empty()) {
+    tokens.push_back(current);
+  }
+  return tokens;
+}
+
+std::unordered_set<std::string> TokenSetForRerank(const std::string& text) {
+  std::vector<std::string> tokens = TokenizeForRerank(text);
+  return std::unordered_set<std::string>(tokens.begin(), tokens.end());
+}
+
+}  // namespace
 
 static std::string ReadStringEnv(const char* name, const char* default_value) {
   const char* value = std::getenv(name);
@@ -124,6 +157,76 @@ grpc::Status EmbeddingServiceImpl::GetEmbeddings(
     }
     item->set_error("");
   }
+  response->set_error("");
+  return grpc::Status::OK;
+}
+
+grpc::Status EmbeddingServiceImpl::Rerank(grpc::ServerContext*,
+                                          const embedding::RerankRequest* request,
+                                          embedding::RerankResponse* response) {
+  const int query_count = request->queries_size();
+  if (query_count <= 0) {
+    response->set_error("queries must not be empty");
+    return grpc::Status::OK;
+  }
+
+  for (const auto& query : request->queries()) {
+    auto* result = response->add_results();
+    if (query.query().empty()) {
+      result->set_error("query must not be empty");
+      continue;
+    }
+    if (query.documents_size() <= 0) {
+      result->set_error("documents must not be empty");
+      continue;
+    }
+
+    const auto query_tokens = TokenSetForRerank(query.query());
+    if (query_tokens.empty()) {
+      result->set_error("query must not be empty");
+      continue;
+    }
+
+    struct Candidate {
+      int index;
+      std::string document;
+      float score;
+    };
+
+    std::vector<Candidate> candidates;
+    candidates.reserve(static_cast<size_t>(query.documents_size()));
+    for (int i = 0; i < query.documents_size(); ++i) {
+      const std::string& document = query.documents(i);
+      const auto doc_tokens = TokenSetForRerank(document);
+      int overlap = 0;
+      for (const auto& token : doc_tokens) {
+        if (query_tokens.count(token) > 0) {
+          ++overlap;
+        }
+      }
+      candidates.push_back({i, document, static_cast<float>(overlap)});
+    }
+
+    std::stable_sort(candidates.begin(), candidates.end(),
+                     [](const Candidate& lhs, const Candidate& rhs) {
+                       return lhs.score > rhs.score;
+                     });
+
+    int top_k = query.top_k();
+    if (top_k <= 0 || top_k > static_cast<int>(candidates.size())) {
+      top_k = static_cast<int>(candidates.size());
+    }
+
+    for (int i = 0; i < top_k; ++i) {
+      const auto& candidate = candidates[static_cast<size_t>(i)];
+      auto* item = result->add_items();
+      item->set_index(candidate.index);
+      item->set_document(candidate.document);
+      item->set_score(candidate.score);
+    }
+    result->set_error("");
+  }
+
   response->set_error("");
   return grpc::Status::OK;
 }

--- a/local_embedding_service/test_all_features.sh
+++ b/local_embedding_service/test_all_features.sh
@@ -68,7 +68,7 @@ grpcurl_call() {
 }
 
 service_is_ready() {
-  grpcurl_call list >/dev/null 2>&1
+  grpcurl_call embedding.EmbeddingService/Info >/dev/null 2>&1
 }
 
 cleanup() {
@@ -216,6 +216,13 @@ main() {
   check_file_contains "$SCRIPT_DIR/src/onnx_embedding_backend.cpp" "GetTensorMutableData" "Embedding extraction from ONNX output implemented"
   echo ""
 
+  echo "阶段五点五：Rerank 接口"
+  echo "----------------------------------------"
+  check_file_contains "$PROTO_FILE" "RerankRequest" "Proto defines RerankRequest"
+  check_file_contains "$PROTO_FILE" "RerankResponse" "Proto defines RerankResponse"
+  check_file_contains "$PROTO_FILE" "rpc Rerank" "EmbeddingService exposes Rerank RPC"
+  echo ""
+
   echo "阶段六：模型加载与集成测试"
   echo "----------------------------------------"
   if start_local_server_if_needed; then
@@ -284,6 +291,36 @@ main() {
       test_result 0 "GetEmbeddings returns multiple embedding results"
     else
       test_result 1 "GetEmbeddings returns insufficient embedding results"
+    fi
+
+    RERANK_OUTPUT="$(grpcurl_call -d '{"queries":[{"query":"hello world","documents":["hello world doc","irrelevant text","world hello again"],"top_k":2}]}' embedding.EmbeddingService/Rerank 2>&1)"
+    echo "$RERANK_OUTPUT"
+    if echo "$RERANK_OUTPUT" | grep -q '"results"'; then
+      test_result 0 "Rerank endpoint returns results"
+    else
+      test_result 1 "Rerank endpoint doesn't return results"
+    fi
+
+    if echo "$RERANK_OUTPUT" | grep -q '"items"'; then
+      test_result 0 "Rerank endpoint returns items"
+    else
+      test_result 1 "Rerank endpoint doesn't return items"
+    fi
+
+    RERANK_ITEM_COUNT="$(echo "$RERANK_OUTPUT" | grep -c '"document"' || true)"
+    if [ "$RERANK_ITEM_COUNT" -ge 2 ]; then
+      test_result 0 "Rerank returns ranked items"
+    else
+      test_result 1 "Rerank returns insufficient ranked items"
+    fi
+
+    RERANK_BATCH_OUTPUT="$(grpcurl_call -d '{"queries":[{"query":"alpha beta","documents":["alpha","beta","gamma"],"top_k":1},{"query":"cat dog","documents":["cat","dog","bird"],"top_k":2}]}' embedding.EmbeddingService/Rerank 2>&1)"
+    echo "$RERANK_BATCH_OUTPUT"
+    RERANK_RESULT_COUNT="$(echo "$RERANK_BATCH_OUTPUT" | grep -c '"items"' || true)"
+    if [ "$RERANK_RESULT_COUNT" -ge 2 ]; then
+      test_result 0 "Rerank supports batch queries"
+    else
+      test_result 1 "Rerank batch query results are missing"
     fi
 
     echo ""

--- a/local_embedding_service/使用方法.md
+++ b/local_embedding_service/使用方法.md
@@ -41,6 +41,14 @@ cd /your_path/go_projects/OmniGateway/local_embedding_service/build
 
 说明：
 - `test_onnx_fallback.sh` 用于验证 Issue #16 的 fallback 场景：当 ONNX 初始化失败时，服务自动回退到 Mock 后端并保持可用。
+- `test_all_features.sh` 已包含 Issue #17 的 Rerank 接口验证。
+
+## 5. 手动验证 Rerank 接口
+```bash
+grpcurl -plaintext -import-path proto -proto proto/embedding.proto \
+  -d '{"queries":[{"query":"hello world","documents":["hello world doc","irrelevant text","world hello again"],"top_k":2}]}' \
+  localhost:50051 embedding.EmbeddingService/Rerank
+```
 
 # 使用docker
 


### PR DESCRIPTION
…solves#17

- Added Rerank RPC to the EmbeddingService in the proto definition.
- Implemented Rerank method in EmbeddingServiceImpl to process queries and rank documents based on token overlap.
- Introduced new message types for RerankRequest, RerankResponse, RerankQuery, RerankItem, and RerankResult.
- Enhanced test_all_features.sh to include tests for the Rerank endpoint.
- Updated documentation to reflect the addition of the Rerank interface and usage examples.