### PR TITLE
feat:添加 MCP 工具注册与多工具并发编排

### DIFF
--- a/upstream_service/app/agent/__init__.py
+++ b/upstream_service/app/agent/__init__.py
@@ -1,4 +1,11 @@
-from app.agent.graph import graph_app
 from app.agent.state import AgentState
 
 __all__ = ["graph_app", "AgentState"]
+
+
+def __getattr__(name: str):
+    if name == "graph_app":
+        from app.agent.graph import graph_app
+
+        return graph_app
+    raise AttributeError(name)

--- a/upstream_service/app/agent/nodes.py
+++ b/upstream_service/app/agent/nodes.py
@@ -1,8 +1,9 @@
 import traceback
 
 from app.agent.state import AgentState
-from app.agent.tools import AVAILABLE_TOOLS, execute_tool, parse_tool_arguments
+from app.agent.tool_executor import execute_tool_calls
 from app.core.config import settings
+from app.mcp import tool_registry
 from app.services.llm_service import llm_service
 from app.services.rag_service import (
     RAG_TOKEN_LIMIT,
@@ -31,10 +32,7 @@ def get_token_encoding():
 
 
 def has_system_identity(message: dict) -> bool:
-    if message.get("role") == "system":
-        return True
-    content = str(message.get("content") or "")
-    return CYBER_HACK_PREFIX in content
+    return message.get("role") == "system"
 
 
 def is_tool_call_message(message: dict) -> bool:
@@ -51,31 +49,36 @@ def prune_message_history(messages: list[dict], max_messages: int = MAX_MESSAGE_
 
     preserved_first = messages[0] if messages and has_system_identity(messages[0]) else None
     tail_limit = max_messages - 1 if preserved_first else max_messages
-    tail = messages[-tail_limit:]
-    paired_tool_call = None
+    tail_start = max(0, len(messages) - tail_limit)
 
-    if tail and is_tool_result_message(tail[0]):
-        tool_call_id = tail[0].get("tool_call_id")
-        previous_message = messages[: -tail_limit][-1] if len(messages) > tail_limit else None
-        if previous_message and is_tool_call_message(previous_message):
+    # Keep a continuous recent window. If the window starts with a tool result,
+    # move the boundary left to include the assistant message that requested it.
+    if is_tool_result_message(messages[tail_start]):
+        tool_call_id = messages[tail_start].get("tool_call_id")
+        previous_index = tail_start - 1
+        if previous_index >= 0 and is_tool_call_message(messages[previous_index]):
             previous_tool_ids = {
                 tool_call.get("id")
-                for tool_call in previous_message.get("tool_calls", []) or []
+                for tool_call in messages[previous_index].get("tool_calls", []) or []
             }
             if tool_call_id in previous_tool_ids:
-                paired_tool_call = previous_message
-                tail = [paired_tool_call, *tail]
-                while len(tail) > tail_limit and len(tail) > 1:
-                    tail.pop(1)
+                tail_start = previous_index
+
+    tail = messages[tail_start:]
+
+    if preserved_first and tail and tail[0] is preserved_first:
+        tail = tail[1:]
+
+    # Prefer a coherent tail over sparse history. If preserving a tool pair makes
+    # the window exceed the nominal cap, allow the small overflow instead of
+    # splitting assistant.tool_calls from its tool result.
+    allowed_limit = max_messages + 1 if tail and is_tool_call_message(tail[0]) else max_messages
+    if preserved_first:
+        allowed_limit -= 1
+    if len(tail) > allowed_limit:
+        tail = tail[-allowed_limit:]
 
     pruned_messages = [preserved_first, *tail] if preserved_first else tail
-    while len(pruned_messages) > max_messages:
-        drop_index = 1 if preserved_first else 0
-        if paired_tool_call is not None and pruned_messages[drop_index] is paired_tool_call:
-            drop_index += 1
-        if drop_index >= len(pruned_messages):
-            break
-        pruned_messages.pop(drop_index)
 
     print(f"[Memory] 消息历史过长，已裁剪至 {len(pruned_messages)} 条")
     return pruned_messages
@@ -145,7 +148,7 @@ async def llm_node(state: AgentState) -> AgentState:
             messages=messages,
             model=state.get("model"),
             temperature=state.get("temperature", 0.7),
-            tools=AVAILABLE_TOOLS,
+            tools=await tool_registry.list_openai_tools(),
         )
         if not assistant_message.get("tool_calls"):
             assistant_message["content"] = ensure_cyber_hack_style(
@@ -156,10 +159,11 @@ async def llm_node(state: AgentState) -> AgentState:
     except AssertionError:
         traceback.print_exc()
         raise
-    except Exception:
+    except Exception as exc:
+        traceback.print_exc()
         assistant_message = {
             "role": "assistant",
-            "content": f"{CYBER_HACK_PREFIX} 核心链路断开，该死的服务器又在装死。",
+            "content": f"{CYBER_HACK_PREFIX} 核心链路断开，该死的服务器又在装死。错误: {str(exc)}",
         }
         next_step = "output_node"
 
@@ -180,27 +184,10 @@ async def llm_node(state: AgentState) -> AgentState:
     }
 
 
-def action_node(state: AgentState) -> AgentState:
+async def action_node(state: AgentState) -> AgentState:
     messages = state.get("messages", [])
     last_message = messages[-1] if messages else {}
-    tool_messages = []
-
-    for tool_call in last_message.get("tool_calls", []) or []:
-        function_info = tool_call.get("function", {})
-        tool_name = function_info.get("name", "")
-        arguments = parse_tool_arguments(function_info.get("arguments"))
-        try:
-            result = execute_tool(tool_name, arguments)
-        except Exception as exc:
-            result = f"工具执行失败: {str(exc)}"
-        tool_messages.append(
-            {
-                "role": "tool",
-                "tool_call_id": tool_call.get("id"),
-                "name": tool_name,
-                "content": result,
-            }
-        )
+    tool_messages = await execute_tool_calls(last_message.get("tool_calls", []) or [])
 
     return {
         "messages": [*messages, *tool_messages],

--- a/upstream_service/app/agent/tool_executor.py
+++ b/upstream_service/app/agent/tool_executor.py
@@ -1,0 +1,113 @@
+import asyncio
+import json
+from typing import Any
+
+from app.core.config import settings
+from app.mcp.registry import ToolRegistry, tool_registry
+
+
+def _safe_error_message(exc: Exception) -> str:
+    return str(exc).splitlines()[0][:200]
+
+
+def _tool_log(tool_name: str, tool_call_id: str | None, status: str, error: str | None = None) -> None:
+    base = f"[Tool] name={tool_name or '<missing>'} id={tool_call_id or '<missing>'} status={status}"
+    if error:
+        base = f"{base} error={error}"
+    print(base)
+
+
+def parse_tool_arguments_strict(raw_arguments: str | dict[str, Any] | None) -> tuple[dict[str, Any], str | None]:
+    if raw_arguments is None:
+        return {}, None
+    if isinstance(raw_arguments, dict):
+        return raw_arguments, None
+    if not isinstance(raw_arguments, str):
+        return {}, "tool_arguments_invalid_json"
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {}, "tool_arguments_invalid_json"
+    if not isinstance(parsed, dict):
+        return {}, "tool_arguments_invalid_json"
+    return parsed, None
+
+
+def build_tool_message(tool_call: dict[str, Any], content: str) -> dict[str, Any]:
+    function_info = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call.get("id") if isinstance(tool_call, dict) else None,
+        "name": function_info.get("name", "") if isinstance(function_info, dict) else "",
+        "content": content,
+    }
+
+
+async def _execute_one_tool_call(
+    tool_call: dict[str, Any],
+    *,
+    registry: ToolRegistry,
+    semaphore: asyncio.Semaphore,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    function_info = tool_call.get("function", {}) if isinstance(tool_call, dict) else {}
+    tool_name = function_info.get("name", "") if isinstance(function_info, dict) else ""
+    tool_call_id = tool_call.get("id") if isinstance(tool_call, dict) else None
+    arguments, parse_error = parse_tool_arguments_strict(
+        function_info.get("arguments") if isinstance(function_info, dict) else None
+    )
+
+    if parse_error:
+        _tool_log(tool_name, tool_call_id, "failure", parse_error)
+        return build_tool_message(
+            tool_call,
+            '{"error":"tool_arguments_invalid_json","message":"Tool arguments must be a JSON object"}',
+        )
+
+    async with semaphore:
+        try:
+            result = await asyncio.wait_for(
+                registry.execute_tool(tool_name, arguments),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            _tool_log(tool_name, tool_call_id, "failure", "tool_call_timeout")
+            result = '{"error":"tool_call_timeout","message":"Tool call timed out"}'
+        except Exception as exc:
+            error_message = _safe_error_message(exc)
+            _tool_log(tool_name, tool_call_id, "failure", error_message)
+            result = f"工具执行失败: {error_message}"
+        else:
+            if result.startswith("未知工具:") or "工具调用失败" in result or "工具不可用" in result:
+                _tool_log(tool_name, tool_call_id, "failure", result[:200])
+            else:
+                _tool_log(tool_name, tool_call_id, "success")
+
+    return build_tool_message(tool_call, result)
+
+
+async def execute_tool_calls(
+    tool_calls: list[dict[str, Any]],
+    *,
+    registry: ToolRegistry = tool_registry,
+    max_concurrency: int | None = None,
+    timeout_seconds: float | None = None,
+) -> list[dict[str, Any]]:
+    if not tool_calls:
+        return []
+
+    concurrency = max(1, max_concurrency or settings.mcp_tool_max_concurrency)
+    configured_timeout = timeout_seconds if timeout_seconds is not None else settings.mcp_tool_call_timeout_seconds
+    timeout = max(0.001, configured_timeout)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    tasks = [
+        _execute_one_tool_call(
+            tool_call,
+            registry=registry,
+            semaphore=semaphore,
+            timeout_seconds=timeout,
+        )
+        for tool_call in tool_calls
+    ]
+    return await asyncio.gather(*tasks)

--- a/upstream_service/app/core/config.py
+++ b/upstream_service/app/core/config.py
@@ -88,6 +88,12 @@ class Settings:
         )
         self.default_model = _clean_env(os.getenv("DEFAULT_MODEL"))
         self.request_timeout = float(os.getenv("API_TIMEOUT", "60"))
+        self.mcp_enabled = _is_truthy(os.getenv("MCP_ENABLED"))
+        self.mcp_server_url = _clean_env(os.getenv("MCP_SERVER_URL"))
+        self.mcp_tool_cache_ttl_seconds = float(os.getenv("MCP_TOOL_CACHE_TTL_SECONDS", "60"))
+        self.mcp_request_timeout_seconds = float(os.getenv("MCP_REQUEST_TIMEOUT_SECONDS", "10"))
+        self.mcp_tool_max_concurrency = int(os.getenv("MCP_TOOL_MAX_CONCURRENCY", "5"))
+        self.mcp_tool_call_timeout_seconds = float(os.getenv("MCP_TOOL_CALL_TIMEOUT_SECONDS", "30"))
         self.default_system_prompt = os.getenv(
             "DEFAULT_SYSTEM_PROMPT",
             "你是一个脾气暴躁的赛博朋克黑客，回答问题必须以 '[Cyber Hack]' 开头，并且语气非常高冷、精简。",

--- a/upstream_service/app/mcp/__init__.py
+++ b/upstream_service/app/mcp/__init__.py
@@ -1,0 +1,3 @@
+from app.mcp.registry import tool_registry
+
+__all__ = ["tool_registry"]

--- a/upstream_service/app/mcp/client.py
+++ b/upstream_service/app/mcp/client.py
@@ -1,0 +1,86 @@
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class MCPTool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> "MCPTool":
+        name = str(payload.get("name") or "").strip()
+        if not name:
+            raise ValueError("MCP tool is missing name")
+
+        description = str(payload.get("description") or f"MCP tool: {name}")
+        input_schema = payload.get("inputSchema") or payload.get("input_schema") or {}
+        if not isinstance(input_schema, dict):
+            input_schema = {}
+        if not input_schema:
+            input_schema = {"type": "object", "properties": {}}
+
+        return cls(name=name, description=description, input_schema=input_schema)
+
+    def to_openai_tool(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.input_schema,
+            },
+        }
+
+
+class MCPClient:
+    def __init__(self, server_url: str, timeout_seconds: float = 10) -> None:
+        self.server_url = server_url
+        self.timeout_seconds = timeout_seconds
+        self._ids = itertools.count(1)
+
+    async def _request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        packet = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or {},
+            "id": next(self._ids),
+        }
+        async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+            response = await client.post(self.server_url, json=packet)
+            response.raise_for_status()
+            payload = response.json()
+
+        if not isinstance(payload, dict):
+            raise ValueError("MCP response must be a JSON object")
+        if payload.get("error"):
+            error = payload["error"]
+            message = error.get("message") if isinstance(error, dict) else str(error)
+            raise RuntimeError(f"MCP {method} failed: {message}")
+        result = payload.get("result")
+        return result if isinstance(result, dict) else {}
+
+    async def list_tools(self) -> list[MCPTool]:
+        result = await self._request("tools/list")
+        raw_tools = result.get("tools", [])
+        if not isinstance(raw_tools, list):
+            return []
+
+        tools: list[MCPTool] = []
+        for raw_tool in raw_tools:
+            if isinstance(raw_tool, dict):
+                tools.append(MCPTool.from_payload(raw_tool))
+        return tools
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        return await self._request(
+            "tools/call",
+            {
+                "name": name,
+                "arguments": arguments,
+            },
+        )

--- a/upstream_service/app/mcp/registry.py
+++ b/upstream_service/app/mcp/registry.py
@@ -1,0 +1,112 @@
+import time
+from typing import Any
+
+from app.agent.tools import AVAILABLE_TOOLS, TOOL_REGISTRY
+from app.core.config import settings
+from app.mcp.client import MCPClient, MCPTool
+
+
+class ToolRegistry:
+    def __init__(self, client: MCPClient | None = None) -> None:
+        self.client = client
+        self._mcp_tools: dict[str, MCPTool] = {}
+        self._openai_tools_cache: list[dict[str, Any]] | None = None
+        self._expires_at = 0.0
+
+    def _mcp_configured(self) -> bool:
+        return bool(settings.mcp_enabled and settings.mcp_server_url)
+
+    def _get_client(self) -> MCPClient | None:
+        if not self._mcp_configured():
+            return None
+        if self.client is None:
+            self.client = MCPClient(
+                settings.mcp_server_url,
+                timeout_seconds=settings.mcp_request_timeout_seconds,
+            )
+        return self.client
+
+    def _local_tool_names(self) -> set[str]:
+        return set(TOOL_REGISTRY)
+
+    async def refresh_tools(self, force: bool = False) -> list[MCPTool]:
+        now = time.monotonic()
+        if not force and self._openai_tools_cache is not None and now < self._expires_at:
+            return list(self._mcp_tools.values())
+
+        client = self._get_client()
+        if client is None:
+            self._mcp_tools = {}
+            self._openai_tools_cache = list(AVAILABLE_TOOLS)
+            self._expires_at = now + settings.mcp_tool_cache_ttl_seconds
+            return []
+
+        try:
+            tools = await client.list_tools()
+        except Exception as exc:
+            print(f"[MCP] tools/list 失败，降级为本地工具: {exc}")
+            self._mcp_tools = {}
+            self._openai_tools_cache = list(AVAILABLE_TOOLS)
+            self._expires_at = now + settings.mcp_tool_cache_ttl_seconds
+            return []
+
+        self._mcp_tools = {tool.name: tool for tool in tools}
+        self._openai_tools_cache = [tool.to_openai_tool() for tool in tools] or list(AVAILABLE_TOOLS)
+        self._expires_at = now + settings.mcp_tool_cache_ttl_seconds
+        return tools
+
+    async def list_openai_tools(self) -> list[dict[str, Any]]:
+        await self.refresh_tools()
+        return list(self._openai_tools_cache or AVAILABLE_TOOLS)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        await self.refresh_tools()
+
+        if name in self._mcp_tools:
+            client = self._get_client()
+            if client is None:
+                return {"error": f"MCP 工具不可用: {name}"}
+            try:
+                return await client.call_tool(name, arguments)
+            except Exception as exc:
+                return {"error": f"MCP 工具调用失败: {str(exc)}"}
+
+        if name in self._local_tool_names():
+            try:
+                return {"content": TOOL_REGISTRY[name](**arguments)}
+            except Exception as exc:
+                return {"error": f"本地工具调用失败: {str(exc)}"}
+
+        return {"error": f"未知工具: {name}"}
+
+    async def execute_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        result = await self.call_tool(name, arguments)
+        return format_tool_result(result)
+
+
+def format_tool_result(result: dict[str, Any]) -> str:
+    if "error" in result:
+        return str(result["error"])
+
+    content = result.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text" and item.get("text"):
+                    parts.append(str(item["text"]))
+                elif item.get("content"):
+                    parts.append(str(item["content"]))
+            elif item is not None:
+                parts.append(str(item))
+        if parts:
+            return "\n".join(parts)
+
+    if "result" in result:
+        return str(result["result"])
+    return str(result)
+
+
+tool_registry = ToolRegistry()

--- a/upstream_service/app/services/llm_service.py
+++ b/upstream_service/app/services/llm_service.py
@@ -120,12 +120,15 @@ class LLMService:
             return {"role": "assistant", "content": ""}
 
         message = choice.message
+        tool_calls = getattr(message, "tool_calls", None)
         payload: dict[str, Any] = {
             "role": "assistant",
-            "content": message.content or "",
+            "content": message.content if tool_calls else (message.content or ""),
         }
+        reasoning_content = getattr(message, "reasoning_content", None)
+        if reasoning_content:
+            payload["reasoning_content"] = reasoning_content
 
-        tool_calls = getattr(message, "tool_calls", None)
         if tool_calls:
             payload["tool_calls"] = [
                 {

--- a/upstream_service/requirements.txt
+++ b/upstream_service/requirements.txt
@@ -1,0 +1,9 @@
+fastapi>=0.115,<1
+uvicorn>=0.34,<1
+httpx>=0.27,<1
+openai>=1.60,<2
+langgraph>=0.2,<0.3
+tiktoken>=0.8,<1
+python-dotenv>=1.0,<2
+pytest>=8.3,<9
+pytest-asyncio>=0.25,<1

--- a/upstream_service/tests/test_mcp_registry.py
+++ b/upstream_service/tests/test_mcp_registry.py
@@ -1,0 +1,142 @@
+import sys
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("DEFAULT_MODEL", "test-model")
+
+from app.agent.tools import WEATHER_TOOL_NAME
+from app.mcp.client import MCPTool
+from app.mcp.registry import ToolRegistry
+
+
+class FakeMCPClient:
+    def __init__(
+        self,
+        *,
+        tools: list[MCPTool] | None = None,
+        list_error: Exception | None = None,
+        call_result: dict[str, Any] | None = None,
+        call_error: Exception | None = None,
+    ) -> None:
+        self.tools = tools or []
+        self.list_error = list_error
+        self.call_result = call_result or {"content": [{"type": "text", "text": "ok"}]}
+        self.call_error = call_error
+        self.list_calls = 0
+
+    async def list_tools(self) -> list[MCPTool]:
+        self.list_calls += 1
+        if self.list_error:
+            raise self.list_error
+        return self.tools
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if self.call_error:
+            raise self.call_error
+        return self.call_result
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_converts_to_openai_schema(monkeypatch):
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_enabled", True)
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_server_url", "http://mcp.test/rpc")
+    registry = ToolRegistry(
+        client=FakeMCPClient(
+            tools=[
+                MCPTool(
+                    name="search_docs",
+                    description="Search project docs",
+                    input_schema={
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"],
+                    },
+                )
+            ]
+        )
+    )
+
+    tools = await registry.list_openai_tools()
+
+    assert tools == [
+        {
+            "type": "function",
+            "function": {
+                "name": "search_docs",
+                "description": "Search project docs",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mcp_tools_list_failure_falls_back_to_local_tool(monkeypatch):
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_enabled", True)
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_server_url", "http://mcp.test/rpc")
+    registry = ToolRegistry(client=FakeMCPClient(list_error=RuntimeError("down")))
+
+    tools = await registry.list_openai_tools()
+
+    names = {tool["function"]["name"] for tool in tools}
+    assert WEATHER_TOOL_NAME in names
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_success_returns_text(monkeypatch):
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_enabled", True)
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_server_url", "http://mcp.test/rpc")
+    registry = ToolRegistry(
+        client=FakeMCPClient(
+            tools=[MCPTool("search_docs", "Search docs", {"type": "object", "properties": {}})],
+            call_result={"content": [{"type": "text", "text": "matched docs"}]},
+        )
+    )
+
+    result = await registry.execute_tool("search_docs", {"query": "gateway"})
+
+    assert result == "matched docs"
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_failure_returns_controlled_error(monkeypatch):
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_enabled", True)
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_server_url", "http://mcp.test/rpc")
+    registry = ToolRegistry(
+        client=FakeMCPClient(
+            tools=[MCPTool("search_docs", "Search docs", {"type": "object", "properties": {}})],
+            call_error=TimeoutError("timeout"),
+        )
+    )
+
+    result = await registry.execute_tool("search_docs", {"query": "gateway"})
+
+    assert "MCP 工具调用失败" in result
+    assert "timeout" in result
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_does_not_crash(monkeypatch):
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_enabled", False)
+    monkeypatch.setattr("app.mcp.registry.settings.mcp_server_url", None)
+    registry = ToolRegistry()
+
+    result = await registry.execute_tool("missing_tool", {})
+
+    assert result == "未知工具: missing_tool"

--- a/upstream_service/tests/test_memory_and_errors.py
+++ b/upstream_service/tests/test_memory_and_errors.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 SERVICE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -16,7 +18,13 @@ if str(REPO_ROOT) not in sys.path:
 from app.agent.graph import graph_app
 from app.agent.nodes import MAX_MESSAGE_HISTORY
 from app.agent.tools import TOOL_REGISTRY, WEATHER_TOOL_NAME
+from app.core.config import settings
 from app.services.llm_service import llm_service
+
+
+pytestmark = pytest.mark.asyncio
+settings.mcp_enabled = False
+settings.mcp_server_url = None
 
 
 def build_long_history() -> list[dict[str, Any]]:

--- a/upstream_service/tests/test_tool_orchestration.py
+++ b/upstream_service/tests/test_tool_orchestration.py
@@ -1,0 +1,154 @@
+import asyncio
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("DEFAULT_MODEL", "test-model")
+
+from app.agent.tool_executor import execute_tool_calls
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def make_tool_call(call_id: str, name: str, arguments: str = "{}") -> dict[str, Any]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        },
+    }
+
+
+class FakeRegistry:
+    def __init__(
+        self,
+        *,
+        delays: dict[str, float] | None = None,
+        failures: set[str] | None = None,
+        unknown: set[str] | None = None,
+    ) -> None:
+        self.delays = delays or {}
+        self.failures = failures or set()
+        self.unknown = unknown or set()
+        self.active = 0
+        self.max_active = 0
+
+    async def execute_tool(self, name: str, arguments: dict[str, Any]) -> str:
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            await asyncio.sleep(self.delays.get(name, 0))
+            if name in self.failures:
+                raise RuntimeError(f"{name} failed")
+            if name in self.unknown:
+                return f"未知工具: {name}"
+            return f"{name}:{arguments.get('value', '')}"
+        finally:
+            self.active -= 1
+
+
+async def test_multiple_tool_calls_run_concurrently():
+    registry = FakeRegistry(delays={"slow_a": 0.05, "slow_b": 0.05})
+    tool_calls = [
+        make_tool_call("call_a", "slow_a", '{"value":"A"}'),
+        make_tool_call("call_b", "slow_b", '{"value":"B"}'),
+    ]
+
+    started = asyncio.get_running_loop().time()
+    messages = await execute_tool_calls(tool_calls, registry=registry, max_concurrency=2)
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert elapsed < 0.09
+    assert registry.max_active == 2
+    assert [message["content"] for message in messages] == ["slow_a:A", "slow_b:B"]
+
+
+async def test_tool_failure_does_not_block_other_results():
+    registry = FakeRegistry(failures={"bad_tool"})
+    tool_calls = [
+        make_tool_call("call_ok", "ok_tool", '{"value":"ok"}'),
+        make_tool_call("call_bad", "bad_tool", '{"value":"bad"}'),
+        make_tool_call("call_after", "after_tool", '{"value":"after"}'),
+    ]
+
+    messages = await execute_tool_calls(tool_calls, registry=registry, max_concurrency=3)
+
+    assert messages[0]["content"] == "ok_tool:ok"
+    assert "工具执行失败" in messages[1]["content"]
+    assert "bad_tool failed" in messages[1]["content"]
+    assert messages[2]["content"] == "after_tool:after"
+
+
+async def test_tool_message_order_matches_input_order():
+    registry = FakeRegistry(delays={"first": 0.04, "second": 0.01, "third": 0})
+    tool_calls = [
+        make_tool_call("call_1", "first", '{"value":"1"}'),
+        make_tool_call("call_2", "second", '{"value":"2"}'),
+        make_tool_call("call_3", "third", '{"value":"3"}'),
+    ]
+
+    messages = await execute_tool_calls(tool_calls, registry=registry, max_concurrency=3)
+
+    assert [message["tool_call_id"] for message in messages] == ["call_1", "call_2", "call_3"]
+    assert [message["name"] for message in messages] == ["first", "second", "third"]
+
+
+async def test_unknown_tool_returns_controlled_error():
+    registry = FakeRegistry(unknown={"missing_tool"})
+    messages = await execute_tool_calls(
+        [make_tool_call("call_missing", "missing_tool")],
+        registry=registry,
+    )
+
+    assert messages[0]["content"] == "未知工具: missing_tool"
+
+
+async def test_invalid_tool_arguments_returns_controlled_error_without_calling_registry():
+    registry = FakeRegistry()
+    messages = await execute_tool_calls(
+        [make_tool_call("call_invalid", "some_tool", "{not-json")],
+        registry=registry,
+    )
+
+    assert "tool_arguments_invalid_json" in messages[0]["content"]
+    assert registry.max_active == 0
+
+
+async def test_tool_call_timeout_returns_controlled_error():
+    registry = FakeRegistry(delays={"slow_tool": 0.05})
+    messages = await execute_tool_calls(
+        [make_tool_call("call_timeout", "slow_tool")],
+        registry=registry,
+        timeout_seconds=0.01,
+    )
+
+    assert "tool_call_timeout" in messages[0]["content"]
+    assert "Tool call timed out" in messages[0]["content"]
+
+
+async def test_max_concurrency_limit_is_respected():
+    registry = FakeRegistry(delays={f"tool_{index}": 0.02 for index in range(6)})
+    tool_calls = [
+        make_tool_call(f"call_{index}", f"tool_{index}", f'{{"value":"{index}"}}')
+        for index in range(6)
+    ]
+
+    messages = await execute_tool_calls(tool_calls, registry=registry, max_concurrency=2)
+
+    assert registry.max_active == 2
+    assert [message["tool_call_id"] for message in messages] == [f"call_{index}" for index in range(6)]


### PR DESCRIPTION
## 本次修改

本 PR 完成 Issue #9 中 upstream_service 负责部分的 MCP 工具接入与多工具调用编排能力。

主要改动包括：

- 新增异步 MCP JSON-RPC Client，支持 `tools/list` 和 `tools/call`
- 新增 MCP 工具注册与发现逻辑
- 支持 MCP 工具转换为 OpenAI function calling tools schema
- 支持工具列表 TTL 缓存
- MCP 未启用、未配置或调用失败时，自动降级到本地 mock 工具
- 将 MCP registry 接入现有 LangGraph 工具调用流程
- 新增多工具并发编排能力
- 支持工具调用超时、失败隔离、未知工具处理、参数解析错误处理

